### PR TITLE
講義一覧ページに必要なエンドポイントをopenapi.ymlに定義

### DIFF
--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -163,3 +163,35 @@ paths:
                   year: { type: number, example: 2016 }
                   term: { type: string, example: "秋2" }
                   department_id: { type: number, example: 8 }
+  "/lectures/search":
+    post:
+      tags:
+        - lectures
+      summary: "講義を検索"
+      deprecated: false
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    id: { type: number, example: 1 }
+                    name: { type: string, example: "量子化学3" }
+                    teacher_name: { type: string, example: "田中角栄" }
+                    grade: { type: number, example: 3 }
+                    year: { type: number, example: 2018 }
+                    term: { type: string, example: "春2" }
+                    department_id: { type: number, example: 3 }
+      requestBody:
+        description: "フリーワード検索"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                properties:
+                  word: { type: string, example: "量子" }

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -118,16 +118,22 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  properties:
-                    id: { type: number, example: 1 }
-                    name: { type: string, example: "有機化学3" }
-                    teacher_name: { type: string, example: "田中角栄" }
-                    grade: { type: number, example: 3 }
-                    year: { type: number, example: 2018 }
-                    term: { type: string, example: "春2" }
-                    department_id: { type: number, example: 3 }
+                type: object
+                properties:
+                  lectures:
+                    type: array
+                    items:
+                      properties:
+                        id: { type: number, example: 1 }
+                        name: { type: string, example: "有機化学3" }
+                        teacherName: { type: string, example: "田中角栄" }
+                        grade: { type: string, example: "B2" }
+                        year: { type: number, example: 2018 }
+                        term: { type: string, example: "春2" }
+                        departmentId: { type: number, example: 3 }
+                  total:
+                    type: number
+                    example: 1
   "/lectures/search":
     post:
       tags:
@@ -140,27 +146,32 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  properties:
-                    id: { type: number, example: 1 }
-                    name: { type: string, example: "量子化学3" }
-                    teacher_name: { type: string, example: "田中角栄" }
-                    grade: { type: number, example: 3 }
-                    year: { type: number, example: 2018 }
-                    term: { type: string, example: "春2" }
-                    department_id: { type: number, example: 3 }
+                type: object
+                properties:
+                  lectures:
+                    type: array
+                    items:
+                      properties:
+                        id: { type: number, example: 1 }
+                        name: { type: string, example: "量子化学3" }
+                        teacherName: { type: string, example: "田中角栄" }
+                        grade: { type: string, example: "B2" }
+                        year: { type: number, example: 2018 }
+                        term: { type: string, example: "春2" }
+                        departmentId: { type: number, example: 3 }
+                  total:
+                    type: number
+                    example: 2
       requestBody:
         description: "絞り込み"
         required: true
         content:
           application/json:
             schema:
-              type: array
-              items:
-                properties:
-                  grade: { type: number, example: 2 }
-                  year: { type: number, example: 2016 }
-                  term: { type: string, example: "秋2" }
-                  department_id: { type: number, example: 8 }
-                  word: { type: string, example: "量子" }
+              type: object
+              properties:
+                grade: { type: string, example: "B2" }
+                year: { type: number, example: 2016 }
+                term: { type: string, example: "秋2" }
+                departmentId: { type: number, example: 8 }
+                word: { type: string, example: "量子" }

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -114,7 +114,7 @@ paths:
       deprecated: false
       responses:
         "200":
-          description: "全ての講義のデータが入った配列"
+          description: "ok"
           content:
             application/json:
               schema:
@@ -128,3 +128,38 @@ paths:
                     year: { type: number, example: 2018 }
                     term: { type: string, example: "春2" }
                     department_id: { type: number, example: 3 }
+  "/lectures/filter":
+    post:
+      tags:
+        - lectures
+      summary: "講義を絞り込み検索"
+      deprecated: false
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    id: { type: number, example: 1 }
+                    name: { type: string, example: "有機化学3" }
+                    teacher_name: { type: string, example: "田中角栄" }
+                    grade: { type: number, example: 3 }
+                    year: { type: number, example: 2018 }
+                    term: { type: string, example: "春2" }
+                    department_id: { type: number, example: 3 }
+      requestBody:
+        description: "絞り込み"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                properties:
+                  grade: { type: number, example: 2 }
+                  year: { type: number, example: 2016 }
+                  term: { type: string, example: "秋2" }
+                  department_id: { type: number, example: 8 }

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -42,8 +42,7 @@ paths:
                 items:
                   properties:
                     file_id: { type: string, example: "xxxxxx-xxxxx" }
-                    name:
-                      { type: string, example: "論理設計及び演習2022期末.pdf" }
+                    name: { type: string, example: "論理設計及び演習2022期末.pdf" }
   "/file":
     post:
       summary: "pdfのアップロード"
@@ -107,3 +106,25 @@ paths:
             schema:
               type: string
               format: binary
+  "/lectures":
+    get:
+      tags:
+        - lectures
+      summary: "講義を全て取得"
+      deprecated: false
+      responses:
+        "200":
+          description: "全ての講義のデータが入った配列"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    id: { type: number, example: 1 }
+                    name: { type: string, example: "有機化学3" }
+                    teacher_name: { type: string, example: "田中角栄" }
+                    grade: { type: number, example: 3 }
+                    year: { type: number, example: 2018 }
+                    term: { type: string, example: "春2" }
+                    department_id: { type: number, example: 3 }

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -128,46 +128,11 @@ paths:
                     year: { type: number, example: 2018 }
                     term: { type: string, example: "春2" }
                     department_id: { type: number, example: 3 }
-  "/lectures/filter":
-    post:
-      tags:
-        - lectures
-      summary: "講義を絞り込み検索"
-      deprecated: false
-      responses:
-        "200":
-          description: "ok"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  properties:
-                    id: { type: number, example: 1 }
-                    name: { type: string, example: "有機化学3" }
-                    teacher_name: { type: string, example: "田中角栄" }
-                    grade: { type: number, example: 3 }
-                    year: { type: number, example: 2018 }
-                    term: { type: string, example: "春2" }
-                    department_id: { type: number, example: 3 }
-      requestBody:
-        description: "絞り込み"
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                properties:
-                  grade: { type: number, example: 2 }
-                  year: { type: number, example: 2016 }
-                  term: { type: string, example: "秋2" }
-                  department_id: { type: number, example: 8 }
   "/lectures/search":
     post:
       tags:
         - lectures
-      summary: "講義を検索"
+      summary: "講義検索"
       deprecated: false
       responses:
         "200":
@@ -186,7 +151,7 @@ paths:
                     term: { type: string, example: "春2" }
                     department_id: { type: number, example: 3 }
       requestBody:
-        description: "フリーワード検索"
+        description: "絞り込み"
         required: true
         content:
           application/json:
@@ -194,4 +159,8 @@ paths:
               type: array
               items:
                 properties:
+                  grade: { type: number, example: 2 }
+                  year: { type: number, example: 2016 }
+                  term: { type: string, example: "秋2" }
+                  department_id: { type: number, example: 8 }
                   word: { type: string, example: "量子" }


### PR DESCRIPTION
以下のようにエンドポイントを定義しました。
- /lecture
  全ての講義情報を取得
- /lecture/filter
  絞り込み検索
- /lecture/search
  フリーワード検索
![スクリーンショット 2023-03-11 4 16 09](https://user-images.githubusercontent.com/83484258/224406053-0a2730ff-b953-4936-8a3f-9e8f06de4c3f.png)

openapi.ymlはswagger edittorで動作確認済みです。
<img width="704" alt="スクリーンショット 2023-03-11 4 17 38" src="https://user-images.githubusercontent.com/83484258/224406311-8ca36320-c0a3-4592-aba5-c66048f25dc8.png">
