### PR TITLE
:+1: ログイン、新規登録周りのエンドポイントを定義 #16

### DIFF
--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -19,11 +19,11 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: JSESSIONID
+      name: SESSIONID
     cookieSignUpAuth:
       type: apiKey
       in: cookie
-      name: UUID
+      name: SIGNUPID
 
 paths:
   "/":
@@ -132,23 +132,23 @@ paths:
             schema:
               type: object
               properties:
-                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+                email: { type: string, example: "foo@s.mail.nagoya-u.ac.jp" }
                 password: { type: string, example: "password" }
       security: [] # no authentication
       responses:
         "200":
           description: >
-            認証に成功すれば、セッションIDが`JSESSIONID`という名前でcookieに入れて返される。
+            認証に成功すれば、セッションIDが`SESSIONID`という名前でcookieに入れて返される。
             付随するリクエストには、このcookieを含める必要がある。
           headers:
             Set-Cookie:
               schema:
                 type: string
-                example: JSESSIONID=abcde12345;
+                example: SESSIONID=abcde12345;
 
   "/signup/mail":
     post:
-      summary: "認証メールを送り、uuidをcookieで返す"
+      summary: "認証メールを送り、SIGNUPIDをcookieで返す"
       tags: ["sign up"]
       deprecated: false
       requestBody:
@@ -159,17 +159,17 @@ paths:
             schema:
               type: object
               properties:
-                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+                email: { type: string, example: "foo@s.mail.nagoya-u.ac.jp" }
       security: [] # no authentication
       responses:
         "200":
           description: >
-            uuid（ユーザーをバックエンド側で一時的に識別するためのID）を`UUID`という名前でcookieに入れて返す。
+            SIGNUPID（ユーザーをバックエンド側で一時的に識別するためのID）を`SIGNUPID`という名前でcookieに入れて返す。
           headers:
             Set-Cookie:
               schema:
                 type: string
-                example: JSESSIONID=uuid;
+                example: SESSIONID=SIGNUPID;
 
   "/signup/auth":
     post:
@@ -184,7 +184,7 @@ paths:
             schema:
               type: object
               properties:
-                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+                email: { type: string, example: "foo@s.mail.nagoya-u.ac.jp" }
       security:
         - cookieSignUpAuth: []
       responses:
@@ -196,7 +196,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+                  email: { type: string, example: "foo@s.mail.nagoya-u.ac.jp" }
 
   "/signup/register":
     post:
@@ -211,7 +211,7 @@ paths:
             schema:
               type: object
               properties:
-                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+                email: { type: string, example: "foo@s.mail.nagoya-u.ac.jp" }
                 name: { type: string, example: "杉山 直" }
                 password: { type: string, example: "password" }
       security:
@@ -219,10 +219,10 @@ paths:
       responses:
         "200":
           description: >
-            登録に成功すれば、セッションIDが`JSESSIONID`という名前でcookieに入れて返される。
+            登録に成功すれば、セッションIDが`SESSIONID`という名前でcookieに入れて返される。
             付随するリクエストには、このcookieを含める必要がある。
           headers:
             Set-Cookie:
               schema:
                 type: string
-                example: JSESSIONID=abcde12345;
+                example: SESSIONID=abcde12345;

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -13,6 +13,18 @@ tags:
   - name: file
     description: pdfの操作
 
+# cookieによるセッション管理の設定
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: JSESSIONID
+    cookieSignUpAuth:
+      type: apiKey
+      in: cookie
+      name: UUID
+
 paths:
   "/":
     get:
@@ -107,3 +119,110 @@ paths:
             schema:
               type: string
               format: binary
+  "/login":
+    post:
+      summary: "ログインしてセッションIDをcookieで返す"
+      tags: ["login"]
+      deprecated: false
+      requestBody:
+        description: "メールアドレスとパスワードを含めたjson"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+                password: { type: string, example: "password" }
+      security: [] # no authentication
+      responses:
+        "200":
+          description: >
+            認証に成功すれば、セッションIDが`JSESSIONID`という名前でcookieに入れて返される。
+            付随するリクエストには、このcookieを含める必要がある。
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: JSESSIONID=abcde12345;
+
+  "/signup/mail":
+    post:
+      summary: "認証メールを送り、uuidをcookieで返す"
+      tags: ["sign up"]
+      deprecated: false
+      requestBody:
+        description: "メールアドレスを含めたjson"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+      security: [] # no authentication
+      responses:
+        "200":
+          description: >
+            uuid（ユーザーをバックエンド側で一時的に識別するためのID）を`UUID`という名前でcookieに入れて返す。
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: JSESSIONID=uuid;
+
+  "/signup/auth":
+    post:
+      summary: "ワンタイムパスワードで本人確認を行う"
+      tags: ["sign up"]
+      deprecated: false
+      requestBody:
+        description: "メールアドレスを含めたjson"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+      security:
+        - cookieSignUpAuth: []
+      responses:
+        "200":
+          description: >
+            認証に成功したら、再びメールアドレスを返す
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+
+  "/signup/register":
+    post:
+      summary: "本登録を行い、セッションIDをcookieで返す"
+      tags: ["sign up"]
+      deprecated: false
+      requestBody:
+        description: "メールアドレス、名前、パスワードを含めたjson"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email: { type: string, example: "foo@a.mail.nagoya-u.ac.jp" }
+                name: { type: string, example: "杉山 直" }
+                password: { type: string, example: "password" }
+      security:
+        - cookieSignUpAuth: []
+      responses:
+        "200":
+          description: >
+            登録に成功すれば、セッションIDが`JSESSIONID`という名前でcookieに入れて返される。
+            付随するリクエストには、このcookieを含める必要がある。
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: JSESSIONID=abcde12345;

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -148,7 +148,7 @@ paths:
 
   "/signup/mail":
     post:
-      summary: "認証メールを送り、SIGNUPIDをcookieで返す"
+      summary: "認証メールを送り、uuidをcookieで返す"
       tags: ["sign up"]
       deprecated: false
       requestBody:
@@ -164,12 +164,12 @@ paths:
       responses:
         "200":
           description: >
-            SIGNUPID（ユーザーをバックエンド側で一時的に識別するためのID）を`SIGNUPID`という名前でcookieに入れて返す。
+            uuid（ユーザーをバックエンド側で一時的に識別するためのID）を`SIGNUPID`という名前でcookieに入れて返す。
           headers:
             Set-Cookie:
               schema:
                 type: string
-                example: SESSIONID=SIGNUPID;
+                example: SIGNUPID=uuid;
 
   "/signup/auth":
     post:


### PR DESCRIPTION
ログインと新規登録周りのエンドポイントを定義しました。

基本的には、この議事録に書いてあることを実装しています。
https://www.notion.so/8e88cb8f47f94461b342b53744cd6c45?pvs=4

- /login : ログイン
- /signup/mail : ワンタイムパスワードをメールで送る
- /signup/auth : ワンタイムパスワードで認証
- /signup/register : 本登録
<img width="565" alt="image" src="https://user-images.githubusercontent.com/83483542/226270065-a197f808-f41e-478a-a8a9-357d03d5a32e.png">

セッションIDやuuidについては、以下のページを参考に、cookieでやりとりするように書いてみました。
https://swagger.io/docs/specification/authentication/cookie-authentication/?sbsearch=login
