### PR TITLE
[add] テストのPDF一覧を取得するためのエンドポイントを設計

### DIFF
--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
   version: 0.0.1
 
 servers:
-  - url: "http://localhost:8080"
+  - url: "http://127.0.0.1:8080"
     description: "ローカル環境"
 
 tags:
@@ -129,6 +129,33 @@ components:
         word:
           type: string
           example: "量子"
+    pdf:
+      type: object
+      description: pdfの詳細
+      properties:
+        id:
+          type: number
+          example: 105
+        name:
+          type: string
+          example: "線形代数学1"
+        user_id:
+          type: number
+          example: 12
+        exam_id:
+          type: number
+          example: 11
+        type:
+          type: string
+          example: "......"
+        created_at:
+          type: string
+          format: date
+          example: "2002-12-13"
+        updated_at:
+          type: string
+          format: date
+          example: "2023-04-08"
 paths:
   "/":
     get:
@@ -217,6 +244,26 @@ paths:
           in: path
           schema: { type: string }
           required: true
+  "/exams/{exam_id}/files":
+    get:
+      tags:
+        - exams
+      summary: "講義idに対するpdfの一覧を返す"
+      responses:
+        "200":
+          description: "ok"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pdfs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/pdf"
+                  total:
+                    type: number
+                    example: 1
   "/lectures":
     get:
       tags:

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -156,6 +156,17 @@ components:
           type: string
           format: date
           example: "2023-04-08"
+    pdf_list:
+      type: object
+      description: "pdf一覧を返すためのオブジェクト"
+      properties:
+        pdfs:
+          type: array
+          items:
+            $ref: "#/components/schemas/pdf"
+        total:
+          type: number
+          example: 1
 paths:
   "/":
     get:
@@ -181,11 +192,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  properties:
-                    fileId: { type: string, example: "xxxxxx-xxxxx" }
-                    name: { type: string, example: "論理設計及び演習2022期末.pdf" }
+                $ref: "#/components/schemas/pdf_list"
     post:
       summary: "新しい講義資料のアップロード"
       tags: ["file"]
@@ -255,15 +262,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  pdfs:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/pdf"
-                  total:
-                    type: number
-                    example: 1
+                $ref: "#/components/schemas/pdf_list"
   "/lectures":
     get:
       tags:


### PR DESCRIPTION
テストを選択した状態でそのテストに紐づけられたPDFの一覧を取得するためのエンドポイントを設計しました

<img width="712" alt="image" src="https://user-images.githubusercontent.com/64479799/230731677-66e07053-b1af-4e90-924a-48bcf01f8033.png">
