### PR TITLE
39 login and signup

### DIFF
--- a/api/$api.ts
+++ b/api/$api.ts
@@ -1,36 +1,36 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import { dataToURLString } from 'aspida'
-import type { Methods as Methods0 } from '.'
-import type { Methods as Methods1 } from './exams/_exam_id/files'
-import type { Methods as Methods2 } from './files'
-import type { Methods as Methods3 } from './files/_fileid@string'
-import type { Methods as Methods4 } from './lectures'
-import type { Methods as Methods5 } from './lectures/_exam_id'
-import type { Methods as Methods6 } from './lectures/search'
-import type { Methods as Methods7 } from './login'
-import type { Methods as Methods8 } from './signup/auth'
-import type { Methods as Methods9 } from './signup/mail'
-import type { Methods as Methods10 } from './signup/register'
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import { dataToURLString } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
+import type { Methods as Methods_1wezual } from './exams/_exam_id/files';
+import type { Methods as Methods_19v0g2l } from './files';
+import type { Methods as Methods_1eqyz61 } from './files/_fileid@string';
+import type { Methods as Methods_iigf21 } from './lectures';
+import type { Methods as Methods_1ci9g1q } from './lectures/_lecture_id/exams';
+import type { Methods as Methods_1a3o5fu } from './lectures/search';
+import type { Methods as Methods_idk8rz } from './login';
+import type { Methods as Methods_1fdblld } from './signup/auth';
+import type { Methods as Methods_jq4fuo } from './signup/mail';
+import type { Methods as Methods_1izjkiy } from './signup/register';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/exams'
-  const PATH1 = '/files'
-  const PATH2 = '/lectures'
-  const PATH3 = '/lectures/search'
-  const PATH4 = '/login'
-  const PATH5 = '/signup/auth'
-  const PATH6 = '/signup/mail'
-  const PATH7 = '/signup/register'
-  const GET = 'GET'
-  const POST = 'POST'
-  const PUT = 'PUT'
-  const DELETE = 'DELETE'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/exams';
+  const PATH1 = '/files';
+  const PATH2 = '/lectures';
+  const PATH3 = '/lectures/search';
+  const PATH4 = '/login';
+  const PATH5 = '/signup/auth';
+  const PATH6 = '/signup/mail';
+  const PATH7 = '/signup/register';
+  const GET = 'GET';
+  const POST = 'POST';
+  const PUT = 'PUT';
+  const DELETE = 'DELETE';
 
   return {
     exams: {
       _exam_id: (val1: number | string) => {
-        const prefix1 = `${PATH0}/${val1}`
+        const prefix1 = `${PATH0}/${val1}`;
 
         return {
           files: {
@@ -38,131 +38,143 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
              * @returns ok
              */
             get: (option?: { config?: T | undefined } | undefined) =>
-              fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, `${prefix1}${PATH1}`, GET, option).json(),
+              fetch<Methods_1wezual['get']['resBody'], BasicHeaders, Methods_1wezual['get']['status']>(prefix, `${prefix1}${PATH1}`, GET, option).json(),
             /**
              * @returns ok
              */
             $get: (option?: { config?: T | undefined } | undefined) =>
-              fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, `${prefix1}${PATH1}`, GET, option).json().then(r => r.body),
-            $path: () => `${prefix}${prefix1}${PATH1}`
-          }
-        }
-      }
+              fetch<Methods_1wezual['get']['resBody'], BasicHeaders, Methods_1wezual['get']['status']>(prefix, `${prefix1}${PATH1}`, GET, option).json().then(r => r.body),
+            $path: () => `${prefix}${prefix1}${PATH1}`,
+          },
+        };
+      },
     },
     files: {
       _fileid: (val1: string) => {
-        const prefix1 = `${PATH1}/${val1}`
+        const prefix1 = `${PATH1}/${val1}`;
 
         return {
           /**
-           * @param option.body - pdfファイル
+           * @returns OK
            */
-          put: (option: { body: Methods3['put']['reqBody'], config?: T | undefined }) =>
-            fetch<void, BasicHeaders, Methods3['put']['status']>(prefix, prefix1, PUT, option).send(),
+          get: (option?: { config?: T | undefined } | undefined) =>
+            fetch<Methods_1eqyz61['get']['resBody'], BasicHeaders, Methods_1eqyz61['get']['status']>(prefix, prefix1, GET, option).blob(),
+          /**
+           * @returns OK
+           */
+          $get: (option?: { config?: T | undefined } | undefined) =>
+            fetch<Methods_1eqyz61['get']['resBody'], BasicHeaders, Methods_1eqyz61['get']['status']>(prefix, prefix1, GET, option).blob().then(r => r.body),
           /**
            * @param option.body - pdfファイル
            */
-          $put: (option: { body: Methods3['put']['reqBody'], config?: T | undefined }) =>
-            fetch<void, BasicHeaders, Methods3['put']['status']>(prefix, prefix1, PUT, option).send().then(r => r.body),
+          put: (option: { body: Methods_1eqyz61['put']['reqBody'], config?: T | undefined }) =>
+            fetch<void, BasicHeaders, Methods_1eqyz61['put']['status']>(prefix, prefix1, PUT, option).send(),
+          /**
+           * @param option.body - pdfファイル
+           */
+          $put: (option: { body: Methods_1eqyz61['put']['reqBody'], config?: T | undefined }) =>
+            fetch<void, BasicHeaders, Methods_1eqyz61['put']['status']>(prefix, prefix1, PUT, option).send().then(r => r.body),
           delete: (option?: { config?: T | undefined } | undefined) =>
-            fetch<void, BasicHeaders, Methods3['delete']['status']>(prefix, prefix1, DELETE, option).send(),
+            fetch<void, BasicHeaders, Methods_1eqyz61['delete']['status']>(prefix, prefix1, DELETE, option).send(),
           $delete: (option?: { config?: T | undefined } | undefined) =>
-            fetch<void, BasicHeaders, Methods3['delete']['status']>(prefix, prefix1, DELETE, option).send().then(r => r.body),
-          $path: () => `${prefix}${prefix1}`
-        }
+            fetch<void, BasicHeaders, Methods_1eqyz61['delete']['status']>(prefix, prefix1, DELETE, option).send().then(r => r.body),
+          $path: () => `${prefix}${prefix1}`,
+        };
       },
       /**
        * @returns OK
        */
       get: (option?: { config?: T | undefined } | undefined) =>
-        fetch<Methods2['get']['resBody'], BasicHeaders, Methods2['get']['status']>(prefix, PATH1, GET, option).json(),
+        fetch<Methods_19v0g2l['get']['resBody'], BasicHeaders, Methods_19v0g2l['get']['status']>(prefix, PATH1, GET, option).json(),
       /**
        * @returns OK
        */
       $get: (option?: { config?: T | undefined } | undefined) =>
-        fetch<Methods2['get']['resBody'], BasicHeaders, Methods2['get']['status']>(prefix, PATH1, GET, option).json().then(r => r.body),
+        fetch<Methods_19v0g2l['get']['resBody'], BasicHeaders, Methods_19v0g2l['get']['status']>(prefix, PATH1, GET, option).json().then(r => r.body),
       /**
        * @param option.body - 講義と講義のテストを指定して講義資料をアップロードする
        * @returns OK
        */
-      post: (option: { body: Methods2['post']['reqBody'], query: Methods2['post']['query'], config?: T | undefined }) =>
-        fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, PATH1, POST, option).json(),
+      post: (option: { body: Methods_19v0g2l['post']['reqBody'], query: Methods_19v0g2l['post']['query'], config?: T | undefined }) =>
+        fetch<Methods_19v0g2l['post']['resBody'], BasicHeaders, Methods_19v0g2l['post']['status']>(prefix, PATH1, POST, option).json(),
       /**
        * @param option.body - 講義と講義のテストを指定して講義資料をアップロードする
        * @returns OK
        */
-      $post: (option: { body: Methods2['post']['reqBody'], query: Methods2['post']['query'], config?: T | undefined }) =>
-        fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, PATH1, POST, option).json().then(r => r.body),
-      $path: (option?: { method: 'post'; query: Methods2['post']['query'] } | undefined) =>
-        `${prefix}${PATH1}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
+      $post: (option: { body: Methods_19v0g2l['post']['reqBody'], query: Methods_19v0g2l['post']['query'], config?: T | undefined }) =>
+        fetch<Methods_19v0g2l['post']['resBody'], BasicHeaders, Methods_19v0g2l['post']['status']>(prefix, PATH1, POST, option).json().then(r => r.body),
+      $path: (option?: { method: 'post'; query: Methods_19v0g2l['post']['query'] } | undefined) =>
+        `${prefix}${PATH1}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`,
     },
     lectures: {
-      _exam_id: (val1: number | string) => {
-        const prefix1 = `${PATH2}/${val1}`
+      _lecture_id: (val1: number | string) => {
+        const prefix1 = `${PATH2}/${val1}`;
 
         return {
-          /**
-           * @returns ok
-           */
-          get: (option?: { config?: T | undefined } | undefined) =>
-            fetch<Methods5['get']['resBody'], BasicHeaders, Methods5['get']['status']>(prefix, prefix1, GET, option).json(),
-          /**
-           * @returns ok
-           */
-          $get: (option?: { config?: T | undefined } | undefined) =>
-            fetch<Methods5['get']['resBody'], BasicHeaders, Methods5['get']['status']>(prefix, prefix1, GET, option).json().then(r => r.body),
-          $path: () => `${prefix}${prefix1}`
-        }
+          exams: {
+            /**
+             * @returns ok
+             */
+            get: (option?: { config?: T | undefined } | undefined) =>
+              fetch<Methods_1ci9g1q['get']['resBody'], BasicHeaders, Methods_1ci9g1q['get']['status']>(prefix, `${prefix1}${PATH0}`, GET, option).json(),
+            /**
+             * @returns ok
+             */
+            $get: (option?: { config?: T | undefined } | undefined) =>
+              fetch<Methods_1ci9g1q['get']['resBody'], BasicHeaders, Methods_1ci9g1q['get']['status']>(prefix, `${prefix1}${PATH0}`, GET, option).json().then(r => r.body),
+            $path: () => `${prefix}${prefix1}${PATH0}`,
+          },
+        };
       },
       search: {
         /**
          * @param option.body - 絞り込み
          * @returns ok
          */
-        post: (option: { body: Methods6['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods6['post']['resBody'], BasicHeaders, Methods6['post']['status']>(prefix, PATH3, POST, option).json(),
+        post: (option: { body: Methods_1a3o5fu['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods_1a3o5fu['post']['resBody'], BasicHeaders, Methods_1a3o5fu['post']['status']>(prefix, PATH3, POST, option).json(),
         /**
          * @param option.body - 絞り込み
          * @returns ok
          */
-        $post: (option: { body: Methods6['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods6['post']['resBody'], BasicHeaders, Methods6['post']['status']>(prefix, PATH3, POST, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH3}`
+        $post: (option: { body: Methods_1a3o5fu['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods_1a3o5fu['post']['resBody'], BasicHeaders, Methods_1a3o5fu['post']['status']>(prefix, PATH3, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH3}`,
       },
       /**
        * @returns ok
        */
       get: (option?: { config?: T | undefined } | undefined) =>
-        fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH2, GET, option).json(),
+        fetch<Methods_iigf21['get']['resBody'], BasicHeaders, Methods_iigf21['get']['status']>(prefix, PATH2, GET, option).json(),
       /**
        * @returns ok
        */
       $get: (option?: { config?: T | undefined } | undefined) =>
-        fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH2, GET, option).json().then(r => r.body),
+        fetch<Methods_iigf21['get']['resBody'], BasicHeaders, Methods_iigf21['get']['status']>(prefix, PATH2, GET, option).json().then(r => r.body),
       /**
        * @param option.body - 講義の名前
        */
-      post: (option: { body: Methods4['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, BasicHeaders, Methods4['post']['status']>(prefix, PATH2, POST, option).send(),
+      post: (option: { body: Methods_iigf21['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, BasicHeaders, Methods_iigf21['post']['status']>(prefix, PATH2, POST, option).send(),
       /**
        * @param option.body - 講義の名前
        */
-      $post: (option: { body: Methods4['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, BasicHeaders, Methods4['post']['status']>(prefix, PATH2, POST, option).send().then(r => r.body),
-      $path: () => `${prefix}${PATH2}`
+      $post: (option: { body: Methods_iigf21['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, BasicHeaders, Methods_iigf21['post']['status']>(prefix, PATH2, POST, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH2}`,
     },
     login: {
       /**
        * @param option.body - メールアドレスとパスワードを含めたjson
        */
-      post: (option: { body: Methods7['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, Methods7['post']['resHeaders'], Methods7['post']['status']>(prefix, PATH4, POST, option).send(),
+      post: (option: { body: Methods_idk8rz['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, Methods_idk8rz['post']['resHeaders'], Methods_idk8rz['post']['status']>(prefix, PATH4, POST, option).send(),
       /**
        * @param option.body - メールアドレスとパスワードを含めたjson
        */
-      $post: (option: { body: Methods7['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, Methods7['post']['resHeaders'], Methods7['post']['status']>(prefix, PATH4, POST, option).send().then(r => r.body),
-      $path: () => `${prefix}${PATH4}`
+      $post: (option: { body: Methods_idk8rz['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, Methods_idk8rz['post']['resHeaders'], Methods_idk8rz['post']['status']>(prefix, PATH4, POST, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH4}`,
     },
     signup: {
       auth: {
@@ -170,56 +182,56 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @param option.body - ワンタイムパスワードを含めたjson
          * @returns 認証に成功したら、再びメールアドレスを返す
          */
-        post: (option: { body: Methods8['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods8['post']['resBody'], BasicHeaders, Methods8['post']['status']>(prefix, PATH5, POST, option).json(),
+        post: (option: { body: Methods_1fdblld['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods_1fdblld['post']['resBody'], BasicHeaders, Methods_1fdblld['post']['status']>(prefix, PATH5, POST, option).json(),
         /**
          * @param option.body - ワンタイムパスワードを含めたjson
          * @returns 認証に成功したら、再びメールアドレスを返す
          */
-        $post: (option: { body: Methods8['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods8['post']['resBody'], BasicHeaders, Methods8['post']['status']>(prefix, PATH5, POST, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH5}`
+        $post: (option: { body: Methods_1fdblld['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods_1fdblld['post']['resBody'], BasicHeaders, Methods_1fdblld['post']['status']>(prefix, PATH5, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH5}`,
       },
       mail: {
         /**
          * @param option.body - メールアドレスを含めたjson
          */
-        post: (option: { body: Methods9['post']['reqBody'], config?: T | undefined }) =>
-          fetch<void, Methods9['post']['resHeaders'], Methods9['post']['status']>(prefix, PATH6, POST, option).send(),
+        post: (option: { body: Methods_jq4fuo['post']['reqBody'], config?: T | undefined }) =>
+          fetch<void, Methods_jq4fuo['post']['resHeaders'], Methods_jq4fuo['post']['status']>(prefix, PATH6, POST, option).send(),
         /**
          * @param option.body - メールアドレスを含めたjson
          */
-        $post: (option: { body: Methods9['post']['reqBody'], config?: T | undefined }) =>
-          fetch<void, Methods9['post']['resHeaders'], Methods9['post']['status']>(prefix, PATH6, POST, option).send().then(r => r.body),
-        $path: () => `${prefix}${PATH6}`
+        $post: (option: { body: Methods_jq4fuo['post']['reqBody'], config?: T | undefined }) =>
+          fetch<void, Methods_jq4fuo['post']['resHeaders'], Methods_jq4fuo['post']['status']>(prefix, PATH6, POST, option).send().then(r => r.body),
+        $path: () => `${prefix}${PATH6}`,
       },
       register: {
         /**
          * @param option.body - メールアドレス、名前、パスワードを含めたjson
          */
-        post: (option: { body: Methods10['post']['reqBody'], config?: T | undefined }) =>
-          fetch<void, Methods10['post']['resHeaders'], Methods10['post']['status']>(prefix, PATH7, POST, option).send(),
+        post: (option: { body: Methods_1izjkiy['post']['reqBody'], config?: T | undefined }) =>
+          fetch<void, Methods_1izjkiy['post']['resHeaders'], Methods_1izjkiy['post']['status']>(prefix, PATH7, POST, option).send(),
         /**
          * @param option.body - メールアドレス、名前、パスワードを含めたjson
          */
-        $post: (option: { body: Methods10['post']['reqBody'], config?: T | undefined }) =>
-          fetch<void, Methods10['post']['resHeaders'], Methods10['post']['status']>(prefix, PATH7, POST, option).send().then(r => r.body),
-        $path: () => `${prefix}${PATH7}`
-      }
+        $post: (option: { body: Methods_1izjkiy['post']['reqBody'], config?: T | undefined }) =>
+          fetch<void, Methods_1izjkiy['post']['resHeaders'], Methods_1izjkiy['post']['status']>(prefix, PATH7, POST, option).send().then(r => r.body),
+        $path: () => `${prefix}${PATH7}`,
+      },
     },
     /**
      * @returns OK
      */
     get: (option?: { config?: T | undefined } | undefined) =>
-      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, '', GET, option).json(),
+      fetch<Methods_by08hd['get']['resBody'], BasicHeaders, Methods_by08hd['get']['status']>(prefix, '', GET, option).json(),
     /**
      * @returns OK
      */
     $get: (option?: { config?: T | undefined } | undefined) =>
-      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, '', GET, option).json().then(r => r.body),
-    $path: () => `${prefix}`
-  }
-}
+      fetch<Methods_by08hd['get']['resBody'], BasicHeaders, Methods_by08hd['get']['status']>(prefix, '', GET, option).json().then(r => r.body),
+    $path: () => `${prefix}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/$api.ts
+++ b/api/$api.ts
@@ -13,7 +13,7 @@ import type { Methods as Methods_jq4fuo } from './signup/mail';
 import type { Methods as Methods_1izjkiy } from './signup/register';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/exams';
   const PATH1 = '/files';
   const PATH2 = '/lectures';

--- a/api/@types/index.ts
+++ b/api/@types/index.ts
@@ -27,11 +27,12 @@ export type Lecture = {
 
 /** 検索用パラメータ */
 export type Lecture_req = {
-  grade?: 'B1' | 'B2' | 'B3' | 'B4' | 'M1' | 'M2' | 'D1' | 'D2' | 'D3' | undefined
-  year?: number | undefined
-  term?: '春' | '秋' | '春1' | '春2' | '秋1' | '秋2' | undefined
-  departmentId?: number | undefined
-  word?: string | undefined
+  grade?: 'B1' | 'B2' | 'B3' | 'B4' | 'M1' | 'M2' | 'D1' | 'D2' | 'D3' | null | undefined
+  year?: number | null | undefined
+  term?: '春' | '秋' | '春1' | '春2' | '秋1' | '秋2' | null | undefined
+  departmentId?: number | null | undefined
+  teacherName?: string | undefined
+  lectureName?: string | undefined
 }
 
 /** pdfの詳細 */
@@ -48,5 +49,19 @@ export type Pdf = {
 /** pdf一覧を返すためのオブジェクト */
 export type Pdf_list = {
   pdfs?: Pdf[] | undefined
+  total?: number | undefined
+}
+
+/** examの詳細 */
+export type Exam = {
+  exam_id?: number | undefined
+  name?: string | undefined
+  lecture_id?: number | undefined
+  year?: number | undefined
+}
+
+/** examの詳細 */
+export type Exam_list = {
+  exams?: Exam[] | undefined
   total?: number | undefined
 }

--- a/api/exams/$api.ts
+++ b/api/exams/$api.ts
@@ -1,15 +1,15 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import type { Methods as Methods0 } from './_exam_id/files'
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods_2aebqs } from './_exam_id/files';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/exams'
-  const PATH1 = '/files'
-  const GET = 'GET'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/exams';
+  const PATH1 = '/files';
+  const GET = 'GET';
 
   return {
     _exam_id: (val0: number | string) => {
-      const prefix0 = `${PATH0}/${val0}`
+      const prefix0 = `${PATH0}/${val0}`;
 
       return {
         files: {
@@ -17,18 +17,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
            * @returns ok
            */
           get: (option?: { config?: T | undefined } | undefined) =>
-            fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, `${prefix0}${PATH1}`, GET, option).json(),
+            fetch<Methods_2aebqs['get']['resBody'], BasicHeaders, Methods_2aebqs['get']['status']>(prefix, `${prefix0}${PATH1}`, GET, option).json(),
           /**
            * @returns ok
            */
           $get: (option?: { config?: T | undefined } | undefined) =>
-            fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, `${prefix0}${PATH1}`, GET, option).json().then(r => r.body),
-          $path: () => `${prefix}${prefix0}${PATH1}`
-        }
-      }
-    }
-  }
-}
+            fetch<Methods_2aebqs['get']['resBody'], BasicHeaders, Methods_2aebqs['get']['status']>(prefix, `${prefix0}${PATH1}`, GET, option).json().then(r => r.body),
+          $path: () => `${prefix}${prefix0}${PATH1}`,
+        },
+      };
+    },
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/exams/$api.ts
+++ b/api/exams/$api.ts
@@ -2,7 +2,7 @@ import type { AspidaClient, BasicHeaders } from 'aspida';
 import type { Methods as Methods_2aebqs } from './_exam_id/files';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/exams';
   const PATH1 = '/files';
   const GET = 'GET';

--- a/api/files/$api.ts
+++ b/api/files/$api.ts
@@ -1,64 +1,74 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import { dataToURLString } from 'aspida'
-import type { Methods as Methods0 } from '.'
-import type { Methods as Methods1 } from './_fileid@string'
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import { dataToURLString } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
+import type { Methods as Methods_1lyjmi5 } from './_fileid@string';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/files'
-  const GET = 'GET'
-  const POST = 'POST'
-  const PUT = 'PUT'
-  const DELETE = 'DELETE'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/files';
+  const GET = 'GET';
+  const POST = 'POST';
+  const PUT = 'PUT';
+  const DELETE = 'DELETE';
 
   return {
     _fileid: (val0: string) => {
-      const prefix0 = `${PATH0}/${val0}`
+      const prefix0 = `${PATH0}/${val0}`;
 
       return {
         /**
-         * @param option.body - pdfファイル
+         * @returns OK
          */
-        put: (option: { body: Methods1['put']['reqBody'], config?: T | undefined }) =>
-          fetch<void, BasicHeaders, Methods1['put']['status']>(prefix, prefix0, PUT, option).send(),
+        get: (option?: { config?: T | undefined } | undefined) =>
+          fetch<Methods_1lyjmi5['get']['resBody'], BasicHeaders, Methods_1lyjmi5['get']['status']>(prefix, prefix0, GET, option).blob(),
+        /**
+         * @returns OK
+         */
+        $get: (option?: { config?: T | undefined } | undefined) =>
+          fetch<Methods_1lyjmi5['get']['resBody'], BasicHeaders, Methods_1lyjmi5['get']['status']>(prefix, prefix0, GET, option).blob().then(r => r.body),
         /**
          * @param option.body - pdfファイル
          */
-        $put: (option: { body: Methods1['put']['reqBody'], config?: T | undefined }) =>
-          fetch<void, BasicHeaders, Methods1['put']['status']>(prefix, prefix0, PUT, option).send().then(r => r.body),
+        put: (option: { body: Methods_1lyjmi5['put']['reqBody'], config?: T | undefined }) =>
+          fetch<void, BasicHeaders, Methods_1lyjmi5['put']['status']>(prefix, prefix0, PUT, option).send(),
+        /**
+         * @param option.body - pdfファイル
+         */
+        $put: (option: { body: Methods_1lyjmi5['put']['reqBody'], config?: T | undefined }) =>
+          fetch<void, BasicHeaders, Methods_1lyjmi5['put']['status']>(prefix, prefix0, PUT, option).send().then(r => r.body),
         delete: (option?: { config?: T | undefined } | undefined) =>
-          fetch<void, BasicHeaders, Methods1['delete']['status']>(prefix, prefix0, DELETE, option).send(),
+          fetch<void, BasicHeaders, Methods_1lyjmi5['delete']['status']>(prefix, prefix0, DELETE, option).send(),
         $delete: (option?: { config?: T | undefined } | undefined) =>
-          fetch<void, BasicHeaders, Methods1['delete']['status']>(prefix, prefix0, DELETE, option).send().then(r => r.body),
-        $path: () => `${prefix}${prefix0}`
-      }
+          fetch<void, BasicHeaders, Methods_1lyjmi5['delete']['status']>(prefix, prefix0, DELETE, option).send().then(r => r.body),
+        $path: () => `${prefix}${prefix0}`,
+      };
     },
     /**
      * @returns OK
      */
     get: (option?: { config?: T | undefined } | undefined) =>
-      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).json(),
+      fetch<Methods_by08hd['get']['resBody'], BasicHeaders, Methods_by08hd['get']['status']>(prefix, PATH0, GET, option).json(),
     /**
      * @returns OK
      */
     $get: (option?: { config?: T | undefined } | undefined) =>
-      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).json().then(r => r.body),
+      fetch<Methods_by08hd['get']['resBody'], BasicHeaders, Methods_by08hd['get']['status']>(prefix, PATH0, GET, option).json().then(r => r.body),
     /**
      * @param option.body - 講義と講義のテストを指定して講義資料をアップロードする
      * @returns OK
      */
-    post: (option: { body: Methods0['post']['reqBody'], query: Methods0['post']['query'], config?: T | undefined }) =>
-      fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json(),
+    post: (option: { body: Methods_by08hd['post']['reqBody'], query: Methods_by08hd['post']['query'], config?: T | undefined }) =>
+      fetch<Methods_by08hd['post']['resBody'], BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).json(),
     /**
      * @param option.body - 講義と講義のテストを指定して講義資料をアップロードする
      * @returns OK
      */
-    $post: (option: { body: Methods0['post']['reqBody'], query: Methods0['post']['query'], config?: T | undefined }) =>
-      fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
-    $path: (option?: { method: 'post'; query: Methods0['post']['query'] } | undefined) =>
-      `${prefix}${PATH0}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
-  }
-}
+    $post: (option: { body: Methods_by08hd['post']['reqBody'], query: Methods_by08hd['post']['query'], config?: T | undefined }) =>
+      fetch<Methods_by08hd['post']['resBody'], BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
+    $path: (option?: { method: 'post'; query: Methods_by08hd['post']['query'] } | undefined) =>
+      `${prefix}${PATH0}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/files/$api.ts
+++ b/api/files/$api.ts
@@ -4,7 +4,7 @@ import type { Methods as Methods_by08hd } from '.';
 import type { Methods as Methods_1lyjmi5 } from './_fileid@string';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/files';
   const GET = 'GET';
   const POST = 'POST';

--- a/api/files/_fileid@string/index.ts
+++ b/api/files/_fileid@string/index.ts
@@ -2,6 +2,12 @@
 import type { ReadStream } from 'fs'
 
 export type Methods = {
+  get: {
+    status: 200
+    /** OK */
+    resBody: Blob
+  }
+
   put: {
     status: 200
     /** pdfファイル */

--- a/api/files/index.ts
+++ b/api/files/index.ts
@@ -15,7 +15,7 @@ export type Methods = {
 
     /** OK */
     resBody: {
-      fileId: string
+      fileId?: string | undefined
     }
 
     /** 講義と講義のテストを指定して講義資料をアップロードする */

--- a/api/index.ts
+++ b/api/index.ts
@@ -5,7 +5,7 @@ export type Methods = {
 
     /** OK */
     resBody: {
-      message: string
+      message?: string | undefined
     }
   }
 }

--- a/api/lectures/$api.ts
+++ b/api/lectures/$api.ts
@@ -1,71 +1,74 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import type { Methods as Methods0 } from '.'
-import type { Methods as Methods1 } from './_exam_id'
-import type { Methods as Methods2 } from './search'
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
+import type { Methods as Methods_1rmpaye } from './_lecture_id/exams';
+import type { Methods as Methods_4ofto2 } from './search';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/lectures'
-  const PATH1 = '/lectures/search'
-  const GET = 'GET'
-  const POST = 'POST'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/lectures';
+  const PATH1 = '/exams';
+  const PATH2 = '/lectures/search';
+  const GET = 'GET';
+  const POST = 'POST';
 
   return {
-    _exam_id: (val0: number | string) => {
-      const prefix0 = `${PATH0}/${val0}`
+    _lecture_id: (val0: number | string) => {
+      const prefix0 = `${PATH0}/${val0}`;
 
       return {
-        /**
-         * @returns ok
-         */
-        get: (option?: { config?: T | undefined } | undefined) =>
-          fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, prefix0, GET, option).json(),
-        /**
-         * @returns ok
-         */
-        $get: (option?: { config?: T | undefined } | undefined) =>
-          fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, prefix0, GET, option).json().then(r => r.body),
-        $path: () => `${prefix}${prefix0}`
-      }
+        exams: {
+          /**
+           * @returns ok
+           */
+          get: (option?: { config?: T | undefined } | undefined) =>
+            fetch<Methods_1rmpaye['get']['resBody'], BasicHeaders, Methods_1rmpaye['get']['status']>(prefix, `${prefix0}${PATH1}`, GET, option).json(),
+          /**
+           * @returns ok
+           */
+          $get: (option?: { config?: T | undefined } | undefined) =>
+            fetch<Methods_1rmpaye['get']['resBody'], BasicHeaders, Methods_1rmpaye['get']['status']>(prefix, `${prefix0}${PATH1}`, GET, option).json().then(r => r.body),
+          $path: () => `${prefix}${prefix0}${PATH1}`,
+        },
+      };
     },
     search: {
       /**
        * @param option.body - 絞り込み
        * @returns ok
        */
-      post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
-        fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, PATH1, POST, option).json(),
+      post: (option: { body: Methods_4ofto2['post']['reqBody'], config?: T | undefined }) =>
+        fetch<Methods_4ofto2['post']['resBody'], BasicHeaders, Methods_4ofto2['post']['status']>(prefix, PATH2, POST, option).json(),
       /**
        * @param option.body - 絞り込み
        * @returns ok
        */
-      $post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
-        fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, PATH1, POST, option).json().then(r => r.body),
-      $path: () => `${prefix}${PATH1}`
+      $post: (option: { body: Methods_4ofto2['post']['reqBody'], config?: T | undefined }) =>
+        fetch<Methods_4ofto2['post']['resBody'], BasicHeaders, Methods_4ofto2['post']['status']>(prefix, PATH2, POST, option).json().then(r => r.body),
+      $path: () => `${prefix}${PATH2}`,
     },
     /**
      * @returns ok
      */
     get: (option?: { config?: T | undefined } | undefined) =>
-      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).json(),
+      fetch<Methods_by08hd['get']['resBody'], BasicHeaders, Methods_by08hd['get']['status']>(prefix, PATH0, GET, option).json(),
     /**
      * @returns ok
      */
     $get: (option?: { config?: T | undefined } | undefined) =>
-      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).json().then(r => r.body),
+      fetch<Methods_by08hd['get']['resBody'], BasicHeaders, Methods_by08hd['get']['status']>(prefix, PATH0, GET, option).json().then(r => r.body),
     /**
      * @param option.body - 講義の名前
      */
-    post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).send(),
+    post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send(),
     /**
      * @param option.body - 講義の名前
      */
-    $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
-    $path: () => `${prefix}${PATH0}`
-  }
-}
+    $post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/lectures/$api.ts
+++ b/api/lectures/$api.ts
@@ -4,7 +4,7 @@ import type { Methods as Methods_1rmpaye } from './_lecture_id/exams';
 import type { Methods as Methods_4ofto2 } from './search';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/lectures';
   const PATH1 = '/exams';
   const PATH2 = '/lectures/search';

--- a/api/lectures/_lecture_id/exams/index.ts
+++ b/api/lectures/_lecture_id/exams/index.ts
@@ -1,10 +1,10 @@
 /* eslint-disable */
-import type * as Types from '../../@types'
+import type * as Types from '../../../@types'
 
 export type Methods = {
   get: {
     status: 200
     /** ok */
-    resBody: Types.Lecture
+    resBody: Types.Exam_list
   }
 }

--- a/api/lectures/index.ts
+++ b/api/lectures/index.ts
@@ -7,8 +7,8 @@ export type Methods = {
 
     /** ok */
     resBody: {
-      lectures: Types.Lecture[]
-      total: number
+      lectures?: Types.Lecture[] | undefined
+      total?: number | undefined
     }
   }
 

--- a/api/lectures/search/$api.ts
+++ b/api/lectures/search/$api.ts
@@ -2,7 +2,7 @@ import type { AspidaClient, BasicHeaders } from 'aspida';
 import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/lectures/search';
   const POST = 'POST';
 

--- a/api/lectures/search/$api.ts
+++ b/api/lectures/search/$api.ts
@@ -1,27 +1,27 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import type { Methods as Methods0 } from '.'
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/lectures/search'
-  const POST = 'POST'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/lectures/search';
+  const POST = 'POST';
 
   return {
     /**
      * @param option.body - 絞り込み
      * @returns ok
      */
-    post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json(),
+    post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<Methods_by08hd['post']['resBody'], BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).json(),
     /**
      * @param option.body - 絞り込み
      * @returns ok
      */
-    $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
-    $path: () => `${prefix}${PATH0}`
-  }
-}
+    $post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<Methods_by08hd['post']['resBody'], BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/lectures/search/index.ts
+++ b/api/lectures/search/index.ts
@@ -7,11 +7,11 @@ export type Methods = {
 
     /** ok */
     resBody: {
-      lectures: Types.Lecture[]
-      total: number
+      lectures?: Types.Lecture[] | undefined
+      total?: number | undefined
     }
 
     /** 絞り込み */
-    reqBody: Partial<Types.Lecture_req>
+    reqBody: Types.Lecture_req
   }
 }

--- a/api/login/$api.ts
+++ b/api/login/$api.ts
@@ -1,25 +1,25 @@
-import type { AspidaClient } from 'aspida'
-import type { Methods as Methods0 } from '.'
+import type { AspidaClient } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/login'
-  const POST = 'POST'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/login';
+  const POST = 'POST';
 
   return {
     /**
      * @param option.body - メールアドレスとパスワードを含めたjson
      */
-    post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, Methods0['post']['resHeaders'], Methods0['post']['status']>(prefix, PATH0, POST, option).send(),
+    post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, Methods_by08hd['post']['resHeaders'], Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send(),
     /**
      * @param option.body - メールアドレスとパスワードを含めたjson
      */
-    $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, Methods0['post']['resHeaders'], Methods0['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
-    $path: () => `${prefix}${PATH0}`
-  }
-}
+    $post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, Methods_by08hd['post']['resHeaders'], Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/login/$api.ts
+++ b/api/login/$api.ts
@@ -2,7 +2,7 @@ import type { AspidaClient } from 'aspida';
 import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/login';
   const POST = 'POST';
 

--- a/api/login/index.ts
+++ b/api/login/index.ts
@@ -9,8 +9,8 @@ export type Methods = {
 
     /** メールアドレスとパスワードを含めたjson */
     reqBody: {
-      email: string
-      password: string
+      email?: string | undefined
+      password?: string | undefined
     }
   }
 }

--- a/api/signup/$api.ts
+++ b/api/signup/$api.ts
@@ -4,7 +4,7 @@ import type { Methods as Methods_1paaqvt } from './mail';
 import type { Methods as Methods_1pbnd9f } from './register';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/signup/auth';
   const PATH1 = '/signup/mail';
   const PATH2 = '/signup/register';

--- a/api/signup/$api.ts
+++ b/api/signup/$api.ts
@@ -1,14 +1,14 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import type { Methods as Methods0 } from './auth'
-import type { Methods as Methods1 } from './mail'
-import type { Methods as Methods2 } from './register'
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods_163xhtc } from './auth';
+import type { Methods as Methods_1paaqvt } from './mail';
+import type { Methods as Methods_1pbnd9f } from './register';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/signup/auth'
-  const PATH1 = '/signup/mail'
-  const PATH2 = '/signup/register'
-  const POST = 'POST'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/signup/auth';
+  const PATH1 = '/signup/mail';
+  const PATH2 = '/signup/register';
+  const POST = 'POST';
 
   return {
     auth: {
@@ -16,44 +16,44 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @param option.body - ワンタイムパスワードを含めたjson
        * @returns 認証に成功したら、再びメールアドレスを返す
        */
-      post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-        fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json(),
+      post: (option: { body: Methods_163xhtc['post']['reqBody'], config?: T | undefined }) =>
+        fetch<Methods_163xhtc['post']['resBody'], BasicHeaders, Methods_163xhtc['post']['status']>(prefix, PATH0, POST, option).json(),
       /**
        * @param option.body - ワンタイムパスワードを含めたjson
        * @returns 認証に成功したら、再びメールアドレスを返す
        */
-      $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-        fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
-      $path: () => `${prefix}${PATH0}`
+      $post: (option: { body: Methods_163xhtc['post']['reqBody'], config?: T | undefined }) =>
+        fetch<Methods_163xhtc['post']['resBody'], BasicHeaders, Methods_163xhtc['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
+      $path: () => `${prefix}${PATH0}`,
     },
     mail: {
       /**
        * @param option.body - メールアドレスを含めたjson
        */
-      post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, Methods1['post']['resHeaders'], Methods1['post']['status']>(prefix, PATH1, POST, option).send(),
+      post: (option: { body: Methods_1paaqvt['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, Methods_1paaqvt['post']['resHeaders'], Methods_1paaqvt['post']['status']>(prefix, PATH1, POST, option).send(),
       /**
        * @param option.body - メールアドレスを含めたjson
        */
-      $post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, Methods1['post']['resHeaders'], Methods1['post']['status']>(prefix, PATH1, POST, option).send().then(r => r.body),
-      $path: () => `${prefix}${PATH1}`
+      $post: (option: { body: Methods_1paaqvt['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, Methods_1paaqvt['post']['resHeaders'], Methods_1paaqvt['post']['status']>(prefix, PATH1, POST, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH1}`,
     },
     register: {
       /**
        * @param option.body - メールアドレス、名前、パスワードを含めたjson
        */
-      post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, Methods2['post']['resHeaders'], Methods2['post']['status']>(prefix, PATH2, POST, option).send(),
+      post: (option: { body: Methods_1pbnd9f['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, Methods_1pbnd9f['post']['resHeaders'], Methods_1pbnd9f['post']['status']>(prefix, PATH2, POST, option).send(),
       /**
        * @param option.body - メールアドレス、名前、パスワードを含めたjson
        */
-      $post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
-        fetch<void, Methods2['post']['resHeaders'], Methods2['post']['status']>(prefix, PATH2, POST, option).send().then(r => r.body),
-      $path: () => `${prefix}${PATH2}`
-    }
-  }
-}
+      $post: (option: { body: Methods_1pbnd9f['post']['reqBody'], config?: T | undefined }) =>
+        fetch<void, Methods_1pbnd9f['post']['resHeaders'], Methods_1pbnd9f['post']['status']>(prefix, PATH2, POST, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH2}`,
+    },
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/signup/auth/$api.ts
+++ b/api/signup/auth/$api.ts
@@ -2,7 +2,7 @@ import type { AspidaClient, BasicHeaders } from 'aspida';
 import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/signup/auth';
   const POST = 'POST';
 

--- a/api/signup/auth/$api.ts
+++ b/api/signup/auth/$api.ts
@@ -1,27 +1,27 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import type { Methods as Methods0 } from '.'
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/signup/auth'
-  const POST = 'POST'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/signup/auth';
+  const POST = 'POST';
 
   return {
     /**
      * @param option.body - ワンタイムパスワードを含めたjson
      * @returns 認証に成功したら、再びメールアドレスを返す
      */
-    post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json(),
+    post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<Methods_by08hd['post']['resBody'], BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).json(),
     /**
      * @param option.body - ワンタイムパスワードを含めたjson
      * @returns 認証に成功したら、再びメールアドレスを返す
      */
-    $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<Methods0['post']['resBody'], BasicHeaders, Methods0['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
-    $path: () => `${prefix}${PATH0}`
-  }
-}
+    $post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<Methods_by08hd['post']['resBody'], BasicHeaders, Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).json().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/signup/auth/index.ts
+++ b/api/signup/auth/index.ts
@@ -5,12 +5,12 @@ export type Methods = {
 
     /** 認証に成功したら、再びメールアドレスを返す */
     resBody: {
-      email: string
+      email?: string | undefined
     }
 
     /** ワンタイムパスワードを含めたjson */
     reqBody: {
-      oneTimePassword: string
+      oneTimePassword?: string | undefined
     }
   }
 }

--- a/api/signup/mail/$api.ts
+++ b/api/signup/mail/$api.ts
@@ -1,25 +1,25 @@
-import type { AspidaClient } from 'aspida'
-import type { Methods as Methods0 } from '.'
+import type { AspidaClient } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/signup/mail'
-  const POST = 'POST'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/signup/mail';
+  const POST = 'POST';
 
   return {
     /**
      * @param option.body - メールアドレスを含めたjson
      */
-    post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, Methods0['post']['resHeaders'], Methods0['post']['status']>(prefix, PATH0, POST, option).send(),
+    post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, Methods_by08hd['post']['resHeaders'], Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send(),
     /**
      * @param option.body - メールアドレスを含めたjson
      */
-    $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, Methods0['post']['resHeaders'], Methods0['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
-    $path: () => `${prefix}${PATH0}`
-  }
-}
+    $post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, Methods_by08hd['post']['resHeaders'], Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/signup/mail/$api.ts
+++ b/api/signup/mail/$api.ts
@@ -2,7 +2,7 @@ import type { AspidaClient } from 'aspida';
 import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/signup/mail';
   const POST = 'POST';
 

--- a/api/signup/mail/index.ts
+++ b/api/signup/mail/index.ts
@@ -9,7 +9,7 @@ export type Methods = {
 
     /** メールアドレスを含めたjson */
     reqBody: {
-      email: string
+      email?: string | undefined
     }
   }
 }

--- a/api/signup/register/$api.ts
+++ b/api/signup/register/$api.ts
@@ -1,25 +1,25 @@
-import type { AspidaClient } from 'aspida'
-import type { Methods as Methods0 } from '.'
+import type { AspidaClient } from 'aspida';
+import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/signup/register'
-  const POST = 'POST'
+  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/signup/register';
+  const POST = 'POST';
 
   return {
     /**
      * @param option.body - メールアドレス、名前、パスワードを含めたjson
      */
-    post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, Methods0['post']['resHeaders'], Methods0['post']['status']>(prefix, PATH0, POST, option).send(),
+    post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, Methods_by08hd['post']['resHeaders'], Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send(),
     /**
      * @param option.body - メールアドレス、名前、パスワードを含めたjson
      */
-    $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-      fetch<void, Methods0['post']['resHeaders'], Methods0['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
-    $path: () => `${prefix}${PATH0}`
-  }
-}
+    $post: (option: { body: Methods_by08hd['post']['reqBody'], config?: T | undefined }) =>
+      fetch<void, Methods_by08hd['post']['resHeaders'], Methods_by08hd['post']['status']>(prefix, PATH0, POST, option).send().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
 
-export type ApiInstance = ReturnType<typeof api>
-export default api
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/api/signup/register/$api.ts
+++ b/api/signup/register/$api.ts
@@ -2,7 +2,7 @@ import type { AspidaClient } from 'aspida';
 import type { Methods as Methods_by08hd } from '.';
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
-  const prefix = (baseURL === undefined ? 'http://127.0.0.1:8080' : baseURL).replace(/\/$/, '');
+  const prefix = (baseURL === undefined ? 'http://localhost:8080' : baseURL).replace(/\/$/, '');
   const PATH0 = '/signup/register';
   const POST = 'POST';
 

--- a/api/signup/register/index.ts
+++ b/api/signup/register/index.ts
@@ -9,9 +9,9 @@ export type Methods = {
 
     /** メールアドレス、名前、パスワードを含めたjson */
     reqBody: {
-      email: string
-      name: string
-      password: string
+      email?: string | undefined
+      name?: string | undefined
+      password?: string | undefined
     }
   }
 }

--- a/components/pages/login/index.vue
+++ b/components/pages/login/index.vue
@@ -1,9 +1,9 @@
 <template>
   <UiHeader />
-  <div class="w-full bg-[#4a8a8a] pt-[5vh] pb-[calc(5vh+60px)]" />
+  <div class="w-full bg-[#4a8a8a] pb-[calc(5vh+60px)] pt-[5vh]" />
 
   <v-card
-    class="mx-auto -mt-[60px] mb-12 min-w-[90vw] max-w-[90vw] md:min-w-[450px] md:max-w-[450px] "
+    class="mx-auto -mt-[60px] mb-12 min-w-[90vw] max-w-[90vw] md:min-w-[450px] md:max-w-[450px]"
   >
     <div
       class="pa-0 flex h-[60px] max-h-[70px] items-end justify-center text-2xl text-[#006E4F]"
@@ -16,24 +16,23 @@
           <div class="mb-2">メールアドレス（@より前を入力）</div>
           <div class="flex">
             <v-responsive class="ma-0 pa-0">
-              <v-text-field
-                v-model="mail"
-              >
-              </v-text-field>
+              <v-text-field v-model="mail" :rules="mailRules"> </v-text-field>
             </v-responsive>
             <div class="ml-2 mt-2">
               <b>@s.mail.nagoya-u.ac.jp</b>
             </div>
           </div>
-
         </div>
         <div>
           <div class="mb-2">パスワード（半角英数字記号で8~40文字）</div>
           <div>
             <v-text-field
-              type="password"
               v-model="password"
               :rules="pwRules"
+              :append-icon="toggle().icon"
+              :type="toggle().type"
+              autocomplete="on"
+              @click:append="showPassword = !showPassword"
             >
             </v-text-field>
           </div>
@@ -45,6 +44,7 @@
       <UiIconButton
         :buttonTitle="'ログイン'"
         :buttonIcon="'mdi-login'"
+        :disabled="!valid"
         v-on:click="postLoginRequest"
       />
     </div>
@@ -53,7 +53,7 @@
     </div>
 
     <div class="mx-auto w-4/5">
-      <div class="mt-6 mb-8 text-center">
+      <div class="mb-8 mt-6 text-center">
         <a href="/signup"><u>アカウントを作成する</u></a>
       </div>
     </div>
@@ -69,11 +69,14 @@
 
   // バリデーション
   const valid = ref<boolean>(false);
-  // const mailRules = [
-  //   (v: string) => !!v || "メールアドレスが未入力です",
-  //   (v: string) =>
-  //     /.+@s\.mail\.nagoya-u\.ac\.jp/.test(v) || "正しい形式で入力してください"
-  // ];
+
+  const showPassword = ref<boolean>(false);
+  const toggle = () => {
+    const icon = showPassword.value ? "mdi-eye" : "mdi-eye-off";
+    const type = showPassword.value ? "text" : "password";
+    return { icon, type };
+  };
+  const mailRules = [(v: string) => !!v || "メールアドレスが未入力です"];
   const pwRules = [
     (v: string) => !!v || "パスワードが未入力です",
     (v: string) =>
@@ -84,22 +87,22 @@
   // ログイン
   const postLoginRequest = async function () {
     if (!valid.value) return;
-    console.log(valid.value);
     console.log(mail.value);
     console.log(password.value);
     client.login
-      .$post({
+      .post({
         body: {
-          email: mail.value,
+          email: mail.value + "@s.mail.nagoya-u.ac.jp",
           password: password.value
         }
       })
       .then((res) => {
         console.log("success", res);
-        //navigateTo("/");
+        window.alert("ログイン成功!");
       })
       .catch((err) => {
         console.error(err);
+        window.alert("ログイン失敗...");
       });
   };
 </script>

--- a/components/pages/signup/auth.vue
+++ b/components/pages/signup/auth.vue
@@ -1,6 +1,6 @@
 <template>
   <UiHeader />
-  <div class="w-full bg-[#4a8a8a] pt-[5vh] pb-[calc(5vh+60px)]">
+  <div class="w-full bg-[#4a8a8a] pb-[calc(5vh+60px)] pt-[5vh]">
     <UiSignupStepBar :stepNumber="2" />
   </div>
 
@@ -39,10 +39,10 @@
     </div>
 
     <div class="mx-auto w-4/5">
-      <div class="mt-6 mb-4 text-center">
+      <div class="mb-4 mt-6 text-center">
         <a href="/signup/auth"><u>パスワードを再送する</u></a>
       </div>
-      <div class="mt-4 mb-8 text-center">
+      <div class="mb-8 mt-4 text-center">
         <a href="/signup"><u>メールアドレスを変更する</u></a>
       </div>
     </div>
@@ -66,8 +66,10 @@
       })
       .then((res) => {
         console.log("success", res);
+        console.log(res.body.email);
+        sessionStorage.setItem("email", res.body.email as string);
         const router = useRouter();
-        router.push("/signup/auth");
+        router.push("/signup/register");
       })
       .catch((err) => {
         console.error(err);

--- a/components/pages/signup/auth.vue
+++ b/components/pages/signup/auth.vue
@@ -22,11 +22,16 @@
       </div>
     </div>
     <div class="mx-auto my-4 w-[85%]">
-      <UiOtpInput v-model="data" :fields="6" />
+      <UiOtpInput v-model="password" :fields="6" />
     </div>
 
     <div class="my-6 text-center">
-      <UiIconButton :buttonTitle="'送信'" :buttonIcon="'mdi-lock'" />
+      <UiIconButton
+        :buttonTitle="'送信'"
+        :buttonIcon="'mdi-lock'"
+        :disabled="password.length !== 6"
+        :onClick="sendOTP"
+      />
     </div>
 
     <div class="mx-auto w-4/5">
@@ -45,15 +50,37 @@
 </template>
 
 <script setup lang="ts">
-const data = ref(null);
+  import { useClient } from "~~/util/api/useApi";
+
+  const client = useClient();
+  const password = ref<string>("");
+  const otp_valid = RegExp(/^[0-9]{6}$/);
+
+  const sendOTP = function () {
+    console.log(password.value);
+    client.signup.auth
+      .post({
+        body: {
+          oneTimePassword: password.value
+        }
+      })
+      .then((res) => {
+        console.log("success", res);
+        const router = useRouter();
+        router.push("/signup/auth");
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
 </script>
 
 <style scoped>
-.v-text-field :deep() input {
-  padding: 0 10px;
-  min-height: 38px;
-}
-.v-text-field :deep() div {
-  padding: 0;
-}
+  .v-text-field :deep() input {
+    padding: 0 10px;
+    min-height: 38px;
+  }
+  .v-text-field :deep() div {
+    padding: 0;
+  }
 </style>

--- a/components/pages/signup/index.vue
+++ b/components/pages/signup/index.vue
@@ -67,6 +67,7 @@
         }
       })
       .then(async (res) => {
+        console.log("success", res);
         const router = useRouter();
         router.push("/signup/auth");
       })

--- a/components/pages/signup/index.vue
+++ b/components/pages/signup/index.vue
@@ -14,20 +14,19 @@
     </div>
     <div class="mx-auto my-4 w-[85%]">
       <div>
-        <div class="my-2">メールアドレス</div>
-        <div>
-          <v-form ref="form" v-model="valid">
-            <v-text-field
-              placeholder="*@s.mail.nagoya-u.ac.jp"
-              :rules="mailRules"
-            >
-            </v-text-field>
-          </v-form>
+        <div class="mb-2">メールアドレス（@より前を入力）</div>
+        <div class="flex">
+          <v-responsive class="ma-0 pa-0">
+            <v-text-field v-model="mail"> </v-text-field>
+          </v-responsive>
+          <div class="ml-2 mt-2">
+            <b>@s.mail.nagoya-u.ac.jp</b>
+          </div>
         </div>
       </div>
     </div>
     <div class="mx-auto w-[90%]">
-      <v-checkbox>
+      <v-checkbox v-model="checkbox">
         <template v-slot:label>
           <div class="text-black">
             <u>
@@ -45,28 +44,46 @@
       <UiIconButton
         :buttonTitle="'メール認証'"
         :buttonIcon="'mdi-email-outline'"
+        :disabled="!checkbox"
+        :onClick="requestMailForSignUp"
       />
     </div>
   </v-card>
 </template>
 
 <script setup lang="ts">
-const valid = false;
-const mailRules = [
-  (v: string) => !!v || "メールアドレスが未入力です",
-  (v: string) =>
-    /.+@s\.mail\.nagoya-u\.ac\.jp/.test(v) || "正しい形式で入力してください",
-];
+  import { useClient } from "~~/util/api/useApi";
 
-let checkbox = false;
+  const client = useClient();
+
+  const mail = ref<string>("");
+  const checkbox = ref<boolean>(false);
+
+  const requestMailForSignUp = function () {
+    client.signup.mail
+      .post({
+        body: {
+          email: mail.value
+        }
+      })
+      .then(async (res) => {
+        const router = useRouter();
+        router.push("/signup/auth");
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  console.log(checkbox.value);
 </script>
 
 <style scoped>
-.v-text-field :deep() input {
-  padding: 0 10px;
-  min-height: 38px;
-}
-.v-text-field :deep() div {
-  padding: 0;
-}
+  .v-text-field :deep() input {
+    padding: 0 10px;
+    min-height: 38px;
+  }
+  .v-text-field :deep() div {
+    padding: 0;
+  }
 </style>

--- a/components/pages/signup/register.vue
+++ b/components/pages/signup/register.vue
@@ -1,6 +1,6 @@
 <template>
   <UiHeader />
-  <div class="w-full bg-[#4a8a8a] pt-[5vh] pb-[calc(5vh+60px)]">
+  <div class="w-full bg-[#4a8a8a] pb-[calc(5vh+60px)] pt-[5vh]">
     <UiSignupStepBar :stepNumber="3" />
   </div>
 
@@ -20,48 +20,85 @@
     </div>
     <div class="mx-auto mb-4 w-[85%]">
       <div>
-        <div class="mt-2">お名前</div>
         <div>
           <v-form ref="form" v-model="valid">
-            <v-text-field />
+            <div class="mt-2">お名前</div>
+            <v-text-field v-model="name" :rules="nameRules" />
+
+            <div>パスワード（半角英数字記号で8~40文字）</div>
+            <v-text-field
+              v-model="password"
+              :rules="pwRules"
+              :append-icon="toggle().icon"
+              :type="toggle().type"
+              autocomplete="on"
+              @click:append="showPassword = !showPassword"
+            />
           </v-form>
-        </div>
-        <div>
-          <div>パスワード</div>
-          <div>
-            <v-form ref="form" v-model="valid">
-              <v-text-field placeholder="半角英数字で8~40文字" :rules="pwRules">
-              </v-text-field>
-            </v-form>
-          </div>
         </div>
       </div>
     </div>
 
-    <div class="mt-2 mb-8 text-center">
-      <UiIconButton :buttonTitle="'本登録'" :buttonIcon="'mdi-account-plus'" />
+    <div class="mb-8 mt-2 text-center">
+      <UiIconButton
+        :buttonTitle="'本登録'"
+        :buttonIcon="'mdi-account-plus'"
+        :disabled="!valid"
+        :onClick="sendUserInfo"
+      />
     </div>
   </v-card>
 </template>
 
 <script setup lang="ts">
-const valid = false;
-const pwRules = [
-  (v: string) => !!v || "パスワードが未入力です",
-  (v: string) =>
-    /^([a-zA-Z0-9!-/:-@¥[-`{-~]{8,})$/.test(v) ||
-    "正しい形式で入力してください",
-];
+  import { useClient } from "~~/util/api/useApi";
 
-let checkbox = false;
+  const client = useClient();
+  const name = ref<string>("");
+  const password = ref<string>("");
+  const showPassword = ref<boolean>(false);
+  const valid = ref<boolean>(false);
+
+  const toggle = () => {
+    const icon = showPassword.value ? "mdi-eye" : "mdi-eye-off";
+    const type = showPassword.value ? "text" : "password";
+    return { icon, type };
+  };
+
+  const nameRules = [(v: string) => !!v || "名前が未入力です"];
+  const pwRules = [
+    (v: string) => !!v || "パスワードが未入力です",
+    (v: string) =>
+      /^([a-zA-Z0-9!-/:-@¥[-`{-~]{8,})$/.test(v) ||
+      "正しい形式で入力してください"
+  ];
+
+  const sendUserInfo = function () {
+    client.signup.register
+      .post({
+        body: {
+          email: sessionStorage.getItem("email") as string,
+          name: name.value,
+          password: password.value
+        }
+      })
+      .then((res) => {
+        console.log("success", res);
+        const router = useRouter();
+        router.push("/");
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
 </script>
 
 <style scoped>
-.v-text-field :deep() input {
-  padding: 0 10px;
-  min-height: 38px;
-}
-.v-text-field :deep() div {
-  padding: 0;
-}
+  .v-text-field :deep() input {
+    padding: 0 10px;
+    min-height: 38px;
+  }
+  .v-text-field :deep() div {
+    padding: 0;
+  }
 </style>

--- a/components/pages/signup/register.vue
+++ b/components/pages/signup/register.vue
@@ -85,9 +85,11 @@
       .then((res) => {
         console.log("success", res);
         const router = useRouter();
+        window.alert("登録完了!");
         router.push("/");
       })
       .catch((err) => {
+        window.alert("登録失敗...");
         console.error(err);
       });
   };

--- a/components/ui/IconButton.vue
+++ b/components/ui/IconButton.vue
@@ -5,6 +5,8 @@
       height="50"
       :prepend-icon="props.buttonIcon"
       color="#006e4f"
+      :disabled="props.disabled"
+      v-on:click="props.onClick"
     >
       <template v-slot:prepend>
         <v-icon color="white"></v-icon>
@@ -17,15 +19,17 @@
 </template>
 
 <script setup lang="ts">
-// プロップス
-interface Props {
-  buttonTitle?: string;
-  buttonIcon?: string;
-}
+  // プロップス
+  interface Props {
+    buttonTitle?: string;
+    buttonIcon?: string;
+    disabled?: boolean;
+    onClick?: () => void;
+  }
 
-// プロップスのデフォルト値
-const props = withDefaults(defineProps<Props>(), {
-  buttonTitle: "ファイルを選択",
-  buttonIcon: "mdi-cloud-upload",
-});
+  // プロップスのデフォルト値
+  const props = withDefaults(defineProps<Props>(), {
+    buttonTitle: "ファイルを選択",
+    buttonIcon: "mdi-cloud-upload"
+  });
 </script>

--- a/components/ui/OtpInput.vue
+++ b/components/ui/OtpInput.vue
@@ -1,55 +1,50 @@
 <script setup lang="ts">
-import { ref, watch, Ref } from "vue";
-const props = defineProps<{
-  fields: number;
-}>();
+  import { ref, watch, Ref } from "vue";
+  const props = defineProps<{
+    fields: number;
+  }>();
 
-const data = ref([]);
-const firstInputEl = ref();
-const emit = defineEmits(["update:modelValue"]);
+  const data = ref([]);
+  const firstInputEl = ref();
+  const emit = defineEmits(["update:modelValue"]);
 
-watch(
-  () => data,
-  (newVal: Ref<string[]>) => {
-    if (newVal.value.length === props.fields && !newVal.value.includes("")) {
-      console.log(Number(newVal.value.join("")));
-      emit("update:modelValue", Number(newVal.value.join("")));
-    } else {
-      emit("update:modelValue", "数字6桁で入力してください");
+  watch(
+    () => data,
+    (newVal: Ref<string[]>) => {
+      emit("update:modelValue", newVal.value.join(""));
+    },
+    { deep: true }
+  );
+
+  const handleOtpInput = (e: Event) => {
+    const { target, data } = e as InputEvent;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (data && target.nextElementSibling) {
+      (target.nextElementSibling as HTMLElement).focus();
+    } else if (data == null && target.previousElementSibling) {
+      (target.previousElementSibling as HTMLElement).focus();
     }
-  },
-  { deep: true }
-);
+  };
 
-const handleOtpInput = (e: Event) => {
-  const { target, data } = e as InputEvent;
-  if (!(target instanceof HTMLInputElement)) return;
-  if (data && target.nextElementSibling) {
-    (target.nextElementSibling as HTMLElement).focus();
-  } else if (data == null && target.previousElementSibling) {
-    (target.previousElementSibling as HTMLElement).focus();
-  }
-};
+  // const handleOtpkeydown = (e) => {
+  //   console.log(e.key);
+  //   if (e.key === "Backspace" && e.target.previousElementSibling) {
+  //     e.target.previousElementSibling.focus();
+  //   }
+  // };
 
-// const handleOtpkeydown = (e) => {
-//   console.log(e.key);
-//   if (e.key === "Backspace" && e.target.previousElementSibling) {
-//     e.target.previousElementSibling.focus();
-//   }
-// };
-
-const handlePaste = (e: ClipboardEvent) => {
-  const pasteData = e.clipboardData ? e.clipboardData.getData("text") : "";
-  let nextEl = firstInputEl.value[0].nextElementSibling;
-  for (let i = 1; i < pasteData.length; i++) {
-    if (nextEl) {
-      data.value[i] = pasteData[i] as never;
-      nextEl = nextEl.nextElementSibling;
+  const handlePaste = (e: ClipboardEvent) => {
+    const pasteData = e.clipboardData ? e.clipboardData.getData("text") : "";
+    let nextEl = firstInputEl.value[0].nextElementSibling;
+    for (let i = 1; i < pasteData.length; i++) {
+      if (nextEl) {
+        data.value[i] = pasteData[i] as never;
+        nextEl = nextEl.nextElementSibling;
+      }
     }
-  }
-};
+  };
 
-// 123456
+  // 123456
 </script>
 
 <template>

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
   version: 0.0.1
 
 servers:
-  - url: "http://127.0.0.1:8080"
+  - url: "http://localhost:8080"
     description: "ローカル環境"
 
 tags:

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -201,6 +201,25 @@ components:
         total:
           type: number
           example: 1
+    ErrorResponse:
+      type: object
+      description: エラーレスポンスの基底型（RFC7807準拠）
+      properties:
+        type:
+          type: string
+          description: エラーの識別子（RFC7807準拠）
+        title:
+          type: string
+          description: 人間が読める形式のエラーの概要（RFC7807準拠）
+        detail:
+          type: string
+          description: 人間が読める形式のエラーの詳細（RFC7807準拠）
+        status:
+          type: integer
+          description: オリジナルAPIサーバが返したHTTPステータスコード（RFC7807準拠）
+      required:
+        - type
+
 paths:
   "/":
     get:
@@ -417,6 +436,34 @@ paths:
               schema:
                 type: string
                 example: SESSIONID=abcde12345;
+        "401":
+          description: 認証エラー(アカウントが存在しない、パスワードが違う とか)
+          content:
+            application/json:
+              schema: 
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                wrongPssword:
+                  type: unauthorized
+                  title: wrongPssword
+                  detail: "パスワードが間違っています"
+                  status: 401
+                userNotExist:
+                  type: unauthorized
+                  title: userNotExist
+                  detail: "アカウントが存在しません"
+                  status: 401
+        "500":
+          description: サーバーエラー
+          content: 
+            application/json:
+              schema: 
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                type: internal_server_error
+                title: Internal Server Error
+                status: 500
+
 
   "/signup/mail":
     post:
@@ -442,6 +489,8 @@ paths:
               schema:
                 type: string
                 example: SIGNUPID=uuid;
+
+
 
   "/signup/auth":
     post:

--- a/util/api/useApi.ts
+++ b/util/api/useApi.ts
@@ -1,6 +1,7 @@
 import { ref } from "vue";
 import api, { ApiInstance } from "~/api/$api";
 import aspida from "@aspida/axios";
+import axios, { AxiosRequestConfig } from "axios";
 
 interface cbType {
   (): Promise<any>;
@@ -21,7 +22,15 @@ export const useAwait = async (cb: cbType) => {
   return { res, error, loading };
 };
 
+// export const useClient = () => {
+//   const client = api(aspida());
+//   return client;
+// };
+
+const config: AxiosRequestConfig = {
+  withCredentials: true,
+};
 export const useClient = () => {
-  const client = api(aspida());
+  const client = api(aspida(axios, config));
   return client;
 };


### PR DESCRIPTION
### やったこと
- /login, /signup のapiを叩いて、アカウントの新規登録とログインができるようにした
- それに合わせてフロントの実装をちょっとだけリファクタリングした
- openapi.yamlに/loginのエラーの記述を追加した

### まだやってないこと
- /loginのエラーハンドリング（バックの実装待ち）