### PR TITLE
lectures/searchに関するスキーマの修正、クライアントの型生成

### DIFF
--- a/api/$api.ts
+++ b/api/$api.ts
@@ -1,20 +1,21 @@
 import type { AspidaClient, BasicHeaders } from "aspida";
 import { dataToURLString } from "aspida";
 import type { Methods as Methods0 } from ".";
-import type { Methods as Methods1 } from "./exams/_exam_id/files";
-import type { Methods as Methods2 } from "./files";
-import type { Methods as Methods3 } from "./files/_fileid@string";
-import type { Methods as Methods4 } from "./lectures";
-import type { Methods as Methods5 } from "./lectures/_exam_id";
-import type { Methods as Methods6 } from "./lectures/search";
-import type { Methods as Methods7 } from "./login";
-import type { Methods as Methods8 } from "./signup/auth";
-import type { Methods as Methods9 } from "./signup/mail";
-import type { Methods as Methods10 } from "./signup/register";
+import type { Methods as Methods1 } from "./exams";
+import type { Methods as Methods2 } from "./exams/_exam_id/files";
+import type { Methods as Methods3 } from "./files";
+import type { Methods as Methods4 } from "./files/_fileid@string";
+import type { Methods as Methods5 } from "./lectures";
+import type { Methods as Methods6 } from "./lectures/_lecture_id/exams";
+import type { Methods as Methods7 } from "./lectures/search";
+import type { Methods as Methods8 } from "./login";
+import type { Methods as Methods9 } from "./signup/auth";
+import type { Methods as Methods10 } from "./signup/mail";
+import type { Methods as Methods11 } from "./signup/register";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
-    baseURL === undefined ? "http://127.0.0.1:8080" : baseURL
+    baseURL === undefined ? "http://localhost:8080" : baseURL
   ).replace(/\/$/, "");
   const PATH0 = "/exams";
   const PATH1 = "/files";
@@ -41,25 +42,54 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
              */
             get: (option?: { config?: T | undefined } | undefined) =>
               fetch<
-                Methods1["get"]["resBody"],
+                Methods2["get"]["resBody"],
                 BasicHeaders,
-                Methods1["get"]["status"]
+                Methods2["get"]["status"]
               >(prefix, `${prefix1}${PATH1}`, GET, option).json(),
             /**
              * @returns ok
              */
             $get: (option?: { config?: T | undefined } | undefined) =>
               fetch<
-                Methods1["get"]["resBody"],
+                Methods2["get"]["resBody"],
                 BasicHeaders,
-                Methods1["get"]["status"]
+                Methods2["get"]["status"]
               >(prefix, `${prefix1}${PATH1}`, GET, option)
                 .json()
                 .then((r) => r.body),
             $path: () => `${prefix}${prefix1}${PATH1}`
           }
         };
-      }
+      },
+      /**
+       * @param option.body - テストの名前
+       */
+      post: (option: {
+        body: Methods1["post"]["reqBody"];
+        config?: T | undefined;
+      }) =>
+        fetch<void, BasicHeaders, Methods1["post"]["status"]>(
+          prefix,
+          PATH0,
+          POST,
+          option
+        ).send(),
+      /**
+       * @param option.body - テストの名前
+       */
+      $post: (option: {
+        body: Methods1["post"]["reqBody"];
+        config?: T | undefined;
+      }) =>
+        fetch<void, BasicHeaders, Methods1["post"]["status"]>(
+          prefix,
+          PATH0,
+          POST,
+          option
+        )
+          .send()
+          .then((r) => r.body),
+      $path: () => `${prefix}${PATH0}`
     },
     files: {
       _fileid: (val1: string) => {
@@ -67,13 +97,33 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
 
         return {
           /**
+           * @returns OK
+           */
+          get: (option?: { config?: T | undefined } | undefined) =>
+            fetch<
+              Methods4["get"]["resBody"],
+              BasicHeaders,
+              Methods4["get"]["status"]
+            >(prefix, prefix1, GET, option).blob(),
+          /**
+           * @returns OK
+           */
+          $get: (option?: { config?: T | undefined } | undefined) =>
+            fetch<
+              Methods4["get"]["resBody"],
+              BasicHeaders,
+              Methods4["get"]["status"]
+            >(prefix, prefix1, GET, option)
+              .blob()
+              .then((r) => r.body),
+          /**
            * @param option.body - pdfファイル
            */
           put: (option: {
-            body: Methods3["put"]["reqBody"];
+            body: Methods4["put"]["reqBody"];
             config?: T | undefined;
           }) =>
-            fetch<void, BasicHeaders, Methods3["put"]["status"]>(
+            fetch<void, BasicHeaders, Methods4["put"]["status"]>(
               prefix,
               prefix1,
               PUT,
@@ -83,10 +133,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
            * @param option.body - pdfファイル
            */
           $put: (option: {
-            body: Methods3["put"]["reqBody"];
+            body: Methods4["put"]["reqBody"];
             config?: T | undefined;
           }) =>
-            fetch<void, BasicHeaders, Methods3["put"]["status"]>(
+            fetch<void, BasicHeaders, Methods4["put"]["status"]>(
               prefix,
               prefix1,
               PUT,
@@ -95,14 +145,14 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
               .send()
               .then((r) => r.body),
           delete: (option?: { config?: T | undefined } | undefined) =>
-            fetch<void, BasicHeaders, Methods3["delete"]["status"]>(
+            fetch<void, BasicHeaders, Methods4["delete"]["status"]>(
               prefix,
               prefix1,
               DELETE,
               option
             ).send(),
           $delete: (option?: { config?: T | undefined } | undefined) =>
-            fetch<void, BasicHeaders, Methods3["delete"]["status"]>(
+            fetch<void, BasicHeaders, Methods4["delete"]["status"]>(
               prefix,
               prefix1,
               DELETE,
@@ -118,18 +168,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        */
       get: (option?: { config?: T | undefined } | undefined) =>
         fetch<
-          Methods2["get"]["resBody"],
+          Methods3["get"]["resBody"],
           BasicHeaders,
-          Methods2["get"]["status"]
+          Methods3["get"]["status"]
         >(prefix, PATH1, GET, option).json(),
       /**
        * @returns OK
        */
       $get: (option?: { config?: T | undefined } | undefined) =>
         fetch<
-          Methods2["get"]["resBody"],
+          Methods3["get"]["resBody"],
           BasicHeaders,
-          Methods2["get"]["status"]
+          Methods3["get"]["status"]
         >(prefix, PATH1, GET, option)
           .json()
           .then((r) => r.body),
@@ -138,34 +188,34 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @returns OK
        */
       post: (option: {
-        body: Methods2["post"]["reqBody"];
-        query: Methods2["post"]["query"];
+        body: Methods3["post"]["reqBody"];
+        query: Methods3["post"]["query"];
         config?: T | undefined;
       }) =>
         fetch<
-          Methods2["post"]["resBody"],
+          Methods3["post"]["resBody"],
           BasicHeaders,
-          Methods2["post"]["status"]
+          Methods3["post"]["status"]
         >(prefix, PATH1, POST, option).json(),
       /**
        * @param option.body - 講義と講義のテストを指定して講義資料をアップロードする
        * @returns OK
        */
       $post: (option: {
-        body: Methods2["post"]["reqBody"];
-        query: Methods2["post"]["query"];
+        body: Methods3["post"]["reqBody"];
+        query: Methods3["post"]["query"];
         config?: T | undefined;
       }) =>
         fetch<
-          Methods2["post"]["resBody"],
+          Methods3["post"]["resBody"],
           BasicHeaders,
-          Methods2["post"]["status"]
+          Methods3["post"]["status"]
         >(prefix, PATH1, POST, option)
           .json()
           .then((r) => r.body),
       $path: (
         option?:
-          | { method: "post"; query: Methods2["post"]["query"] }
+          | { method: "post"; query: Methods3["post"]["query"] }
           | undefined
       ) =>
         `${prefix}${PATH1}${
@@ -173,31 +223,33 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
         }`
     },
     lectures: {
-      _exam_id: (val1: number | string) => {
+      _lecture_id: (val1: number | string) => {
         const prefix1 = `${PATH2}/${val1}`;
 
         return {
-          /**
-           * @returns ok
-           */
-          get: (option?: { config?: T | undefined } | undefined) =>
-            fetch<
-              Methods5["get"]["resBody"],
-              BasicHeaders,
-              Methods5["get"]["status"]
-            >(prefix, prefix1, GET, option).json(),
-          /**
-           * @returns ok
-           */
-          $get: (option?: { config?: T | undefined } | undefined) =>
-            fetch<
-              Methods5["get"]["resBody"],
-              BasicHeaders,
-              Methods5["get"]["status"]
-            >(prefix, prefix1, GET, option)
-              .json()
-              .then((r) => r.body),
-          $path: () => `${prefix}${prefix1}`
+          exams: {
+            /**
+             * @returns ok
+             */
+            get: (option?: { config?: T | undefined } | undefined) =>
+              fetch<
+                Methods6["get"]["resBody"],
+                BasicHeaders,
+                Methods6["get"]["status"]
+              >(prefix, `${prefix1}${PATH0}`, GET, option).json(),
+            /**
+             * @returns ok
+             */
+            $get: (option?: { config?: T | undefined } | undefined) =>
+              fetch<
+                Methods6["get"]["resBody"],
+                BasicHeaders,
+                Methods6["get"]["status"]
+              >(prefix, `${prefix1}${PATH0}`, GET, option)
+                .json()
+                .then((r) => r.body),
+            $path: () => `${prefix}${prefix1}${PATH0}`
+          }
         };
       },
       search: {
@@ -206,26 +258,26 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @returns ok
          */
         post: (option: {
-          body: Methods6["post"]["reqBody"];
+          body: Methods7["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
-            Methods6["post"]["resBody"],
+            Methods7["post"]["resBody"],
             BasicHeaders,
-            Methods6["post"]["status"]
+            Methods7["post"]["status"]
           >(prefix, PATH3, POST, option).json(),
         /**
          * @param option.body - 絞り込み
          * @returns ok
          */
         $post: (option: {
-          body: Methods6["post"]["reqBody"];
+          body: Methods7["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
-            Methods6["post"]["resBody"],
+            Methods7["post"]["resBody"],
             BasicHeaders,
-            Methods6["post"]["status"]
+            Methods7["post"]["status"]
           >(prefix, PATH3, POST, option)
             .json()
             .then((r) => r.body),
@@ -236,18 +288,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        */
       get: (option?: { config?: T | undefined } | undefined) =>
         fetch<
-          Methods4["get"]["resBody"],
+          Methods5["get"]["resBody"],
           BasicHeaders,
-          Methods4["get"]["status"]
+          Methods5["get"]["status"]
         >(prefix, PATH2, GET, option).json(),
       /**
        * @returns ok
        */
       $get: (option?: { config?: T | undefined } | undefined) =>
         fetch<
-          Methods4["get"]["resBody"],
+          Methods5["get"]["resBody"],
           BasicHeaders,
-          Methods4["get"]["status"]
+          Methods5["get"]["status"]
         >(prefix, PATH2, GET, option)
           .json()
           .then((r) => r.body),
@@ -255,10 +307,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @param option.body - 講義の名前
        */
       post: (option: {
-        body: Methods4["post"]["reqBody"];
+        body: Methods5["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<void, BasicHeaders, Methods4["post"]["status"]>(
+        fetch<void, BasicHeaders, Methods5["post"]["status"]>(
           prefix,
           PATH2,
           POST,
@@ -268,10 +320,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @param option.body - 講義の名前
        */
       $post: (option: {
-        body: Methods4["post"]["reqBody"];
+        body: Methods5["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<void, BasicHeaders, Methods4["post"]["status"]>(
+        fetch<void, BasicHeaders, Methods5["post"]["status"]>(
           prefix,
           PATH2,
           POST,
@@ -286,10 +338,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @param option.body - メールアドレスとパスワードを含めたjson
        */
       post: (option: {
-        body: Methods7["post"]["reqBody"];
+        body: Methods8["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<void, Methods7["post"]["resHeaders"], Methods7["post"]["status"]>(
+        fetch<void, Methods8["post"]["resHeaders"], Methods8["post"]["status"]>(
           prefix,
           PATH4,
           POST,
@@ -299,10 +351,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @param option.body - メールアドレスとパスワードを含めたjson
        */
       $post: (option: {
-        body: Methods7["post"]["reqBody"];
+        body: Methods8["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<void, Methods7["post"]["resHeaders"], Methods7["post"]["status"]>(
+        fetch<void, Methods8["post"]["resHeaders"], Methods8["post"]["status"]>(
           prefix,
           PATH4,
           POST,
@@ -319,26 +371,26 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @returns 認証に成功したら、再びメールアドレスを返す
          */
         post: (option: {
-          body: Methods8["post"]["reqBody"];
+          body: Methods9["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
-            Methods8["post"]["resBody"],
+            Methods9["post"]["resBody"],
             BasicHeaders,
-            Methods8["post"]["status"]
+            Methods9["post"]["status"]
           >(prefix, PATH5, POST, option).json(),
         /**
          * @param option.body - ワンタイムパスワードを含めたjson
          * @returns 認証に成功したら、再びメールアドレスを返す
          */
         $post: (option: {
-          body: Methods8["post"]["reqBody"];
+          body: Methods9["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
-            Methods8["post"]["resBody"],
+            Methods9["post"]["resBody"],
             BasicHeaders,
-            Methods8["post"]["status"]
+            Methods9["post"]["status"]
           >(prefix, PATH5, POST, option)
             .json()
             .then((r) => r.body),
@@ -349,25 +401,25 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @param option.body - メールアドレスを含めたjson
          */
         post: (option: {
-          body: Methods9["post"]["reqBody"];
+          body: Methods10["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
             void,
-            Methods9["post"]["resHeaders"],
-            Methods9["post"]["status"]
+            Methods10["post"]["resHeaders"],
+            Methods10["post"]["status"]
           >(prefix, PATH6, POST, option).send(),
         /**
          * @param option.body - メールアドレスを含めたjson
          */
         $post: (option: {
-          body: Methods9["post"]["reqBody"];
+          body: Methods10["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
             void,
-            Methods9["post"]["resHeaders"],
-            Methods9["post"]["status"]
+            Methods10["post"]["resHeaders"],
+            Methods10["post"]["status"]
           >(prefix, PATH6, POST, option)
             .send()
             .then((r) => r.body),
@@ -378,25 +430,25 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @param option.body - メールアドレス、名前、パスワードを含めたjson
          */
         post: (option: {
-          body: Methods10["post"]["reqBody"];
+          body: Methods11["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
             void,
-            Methods10["post"]["resHeaders"],
-            Methods10["post"]["status"]
+            Methods11["post"]["resHeaders"],
+            Methods11["post"]["status"]
           >(prefix, PATH7, POST, option).send(),
         /**
          * @param option.body - メールアドレス、名前、パスワードを含めたjson
          */
         $post: (option: {
-          body: Methods10["post"]["reqBody"];
+          body: Methods11["post"]["reqBody"];
           config?: T | undefined;
         }) =>
           fetch<
             void,
-            Methods10["post"]["resHeaders"],
-            Methods10["post"]["status"]
+            Methods11["post"]["resHeaders"],
+            Methods11["post"]["status"]
           >(prefix, PATH7, POST, option)
             .send()
             .then((r) => r.body),

--- a/api/@types/index.ts
+++ b/api/@types/index.ts
@@ -16,8 +16,8 @@ export type FileExamId = {
 
 /** 講義の詳細 */
 export type Lecture = {
-  id?: number | undefined;
-  name?: string | undefined;
+  id?: string | undefined;
+  lectureName?: string | undefined;
   teacherName?: string | undefined;
   grade?:
     | "B1"
@@ -30,39 +30,22 @@ export type Lecture = {
     | "D2"
     | "D3"
     | undefined;
-  year?: number | undefined;
   term?: "春" | "秋" | "春1" | "春2" | "秋1" | "秋2" | undefined;
-  departmentId?: number | undefined;
 };
 
 /** 検索用パラメータ */
 export type Lecture_req = {
-  grade?:
-    | "B1"
-    | "B2"
-    | "B3"
-    | "B4"
-    | "M1"
-    | "M2"
-    | "D1"
-    | "D2"
-    | "D3"
-    | null
-    | undefined;
-  year?: number | null | undefined;
-  term?: "春" | "秋" | "春1" | "春2" | "秋1" | "秋2" | null | undefined;
-  departmentId?: number | null | undefined;
   teacherName?: string | undefined;
   lectureName?: string | undefined;
 };
 
 /** pdfの詳細 */
 export type Pdf = {
-  id?: number | undefined;
+  id?: string | undefined;
   name?: string | undefined;
-  user_id?: number | undefined;
-  exam_id?: number | undefined;
-  type?: string | undefined;
+  user_id?: string | undefined;
+  exam_id?: string | undefined;
+  type?: "past_exam" | "past_exam_answer" | "other" | undefined;
   created_at?: string | undefined;
   updated_at?: string | undefined;
 };
@@ -75,9 +58,16 @@ export type Pdf_list = {
 
 /** examの詳細 */
 export type Exam = {
-  exam_id?: number | undefined;
-  name?: string | undefined;
-  lecture_id?: number | undefined;
+  exam_id?: string | undefined;
+  type?: "MIDTERM" | "TERMEND" | "OTHER" | undefined;
+  lecture_id?: string | undefined;
+  year?: number | undefined;
+};
+
+/** examの詳細 */
+export type Exam_req = {
+  type?: "MIDTERM" | "TERMEND" | "OTHER" | undefined;
+  lecture_id?: string | undefined;
   year?: number | undefined;
 };
 
@@ -85,4 +75,16 @@ export type Exam = {
 export type Exam_list = {
   exams?: Exam[] | undefined;
   total?: number | undefined;
+};
+
+/** エラーレスポンスの基底型（RFC7807準拠） */
+export type ErrorResponse = {
+  /** エラーの識別子（RFC7807準拠） */
+  type: string;
+  /** 人間が読める形式のエラーの概要（RFC7807準拠） */
+  title?: string | undefined;
+  /** 人間が読める形式のエラーの詳細（RFC7807準拠） */
+  detail?: string | undefined;
+  /** オリジナルAPIサーバが返したHTTPステータスコード（RFC7807準拠） */
+  status?: number | undefined;
 };

--- a/api/@types/index.ts
+++ b/api/@types/index.ts
@@ -37,6 +37,19 @@ export type Lecture = {
 export type Lecture_req = {
   teacherName?: string | undefined;
   lectureName?: string | undefined;
+  grade?:
+    | "B1"
+    | "B2"
+    | "B3"
+    | "B4"
+    | "M1"
+    | "M2"
+    | "D1"
+    | "D2"
+    | "D3"
+    | null
+    | undefined;
+  term?: "春" | "秋" | "春1" | "春2" | "秋1" | "秋2" | null | undefined;
 };
 
 /** pdfの詳細 */

--- a/api/exams/$api.ts
+++ b/api/exams/$api.ts
@@ -1,5 +1,6 @@
 import type { AspidaClient, BasicHeaders } from "aspida";
-import type { Methods as Methods_2aebqs } from "./_exam_id/files";
+import type { Methods as Methods0 } from ".";
+import type { Methods as Methods1 } from "./_exam_id/files";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -8,6 +9,7 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const PATH0 = "/exams";
   const PATH1 = "/files";
   const GET = "GET";
+  const POST = "POST";
 
   return {
     _exam_id: (val0: number | string) => {
@@ -20,25 +22,54 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
            */
           get: (option?: { config?: T | undefined } | undefined) =>
             fetch<
-              Methods_2aebqs["get"]["resBody"],
+              Methods1["get"]["resBody"],
               BasicHeaders,
-              Methods_2aebqs["get"]["status"]
+              Methods1["get"]["status"]
             >(prefix, `${prefix0}${PATH1}`, GET, option).json(),
           /**
            * @returns ok
            */
           $get: (option?: { config?: T | undefined } | undefined) =>
             fetch<
-              Methods_2aebqs["get"]["resBody"],
+              Methods1["get"]["resBody"],
               BasicHeaders,
-              Methods_2aebqs["get"]["status"]
+              Methods1["get"]["status"]
             >(prefix, `${prefix0}${PATH1}`, GET, option)
               .json()
               .then((r) => r.body),
           $path: () => `${prefix}${prefix0}${PATH1}`
         }
       };
-    }
+    },
+    /**
+     * @param option.body - テストの名前
+     */
+    post: (option: {
+      body: Methods0["post"]["reqBody"];
+      config?: T | undefined;
+    }) =>
+      fetch<void, BasicHeaders, Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      ).send(),
+    /**
+     * @param option.body - テストの名前
+     */
+    $post: (option: {
+      body: Methods0["post"]["reqBody"];
+      config?: T | undefined;
+    }) =>
+      fetch<void, BasicHeaders, Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      )
+        .send()
+        .then((r) => r.body),
+    $path: () => `${prefix}${PATH0}`
   };
 };
 

--- a/api/exams/index.ts
+++ b/api/exams/index.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+import type * as Types from "../@types";
+
+export type Methods = {
+  post: {
+    status: 200;
+    /** テストの名前 */
+    reqBody: Types.Exam_req;
+  };
+};

--- a/api/files/$api.ts
+++ b/api/files/$api.ts
@@ -1,7 +1,7 @@
 import type { AspidaClient, BasicHeaders } from "aspida";
 import { dataToURLString } from "aspida";
-import type { Methods as Methods_by08hd } from ".";
-import type { Methods as Methods_1lyjmi5 } from "./_fileid@string";
+import type { Methods as Methods0 } from ".";
+import type { Methods as Methods1 } from "./_fileid@string";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -23,18 +23,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          */
         get: (option?: { config?: T | undefined } | undefined) =>
           fetch<
-            Methods_1lyjmi5["get"]["resBody"],
+            Methods1["get"]["resBody"],
             BasicHeaders,
-            Methods_1lyjmi5["get"]["status"]
+            Methods1["get"]["status"]
           >(prefix, prefix0, GET, option).blob(),
         /**
          * @returns OK
          */
         $get: (option?: { config?: T | undefined } | undefined) =>
           fetch<
-            Methods_1lyjmi5["get"]["resBody"],
+            Methods1["get"]["resBody"],
             BasicHeaders,
-            Methods_1lyjmi5["get"]["status"]
+            Methods1["get"]["status"]
           >(prefix, prefix0, GET, option)
             .blob()
             .then((r) => r.body),
@@ -42,10 +42,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @param option.body - pdfファイル
          */
         put: (option: {
-          body: Methods_1lyjmi5["put"]["reqBody"];
+          body: Methods1["put"]["reqBody"];
           config?: T | undefined;
         }) =>
-          fetch<void, BasicHeaders, Methods_1lyjmi5["put"]["status"]>(
+          fetch<void, BasicHeaders, Methods1["put"]["status"]>(
             prefix,
             prefix0,
             PUT,
@@ -55,10 +55,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @param option.body - pdfファイル
          */
         $put: (option: {
-          body: Methods_1lyjmi5["put"]["reqBody"];
+          body: Methods1["put"]["reqBody"];
           config?: T | undefined;
         }) =>
-          fetch<void, BasicHeaders, Methods_1lyjmi5["put"]["status"]>(
+          fetch<void, BasicHeaders, Methods1["put"]["status"]>(
             prefix,
             prefix0,
             PUT,
@@ -67,14 +67,14 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
             .send()
             .then((r) => r.body),
         delete: (option?: { config?: T | undefined } | undefined) =>
-          fetch<void, BasicHeaders, Methods_1lyjmi5["delete"]["status"]>(
+          fetch<void, BasicHeaders, Methods1["delete"]["status"]>(
             prefix,
             prefix0,
             DELETE,
             option
           ).send(),
         $delete: (option?: { config?: T | undefined } | undefined) =>
-          fetch<void, BasicHeaders, Methods_1lyjmi5["delete"]["status"]>(
+          fetch<void, BasicHeaders, Methods1["delete"]["status"]>(
             prefix,
             prefix0,
             DELETE,
@@ -90,18 +90,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      */
     get: (option?: { config?: T | undefined } | undefined) =>
       fetch<
-        Methods_by08hd["get"]["resBody"],
+        Methods0["get"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["get"]["status"]
+        Methods0["get"]["status"]
       >(prefix, PATH0, GET, option).json(),
     /**
      * @returns OK
      */
     $get: (option?: { config?: T | undefined } | undefined) =>
       fetch<
-        Methods_by08hd["get"]["resBody"],
+        Methods0["get"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["get"]["status"]
+        Methods0["get"]["status"]
       >(prefix, PATH0, GET, option)
         .json()
         .then((r) => r.body),
@@ -110,35 +110,33 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @returns OK
      */
     post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
-      query: Methods_by08hd["post"]["query"];
+      body: Methods0["post"]["reqBody"];
+      query: Methods0["post"]["query"];
       config?: T | undefined;
     }) =>
       fetch<
-        Methods_by08hd["post"]["resBody"],
+        Methods0["post"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["post"]["status"]
+        Methods0["post"]["status"]
       >(prefix, PATH0, POST, option).json(),
     /**
      * @param option.body - 講義と講義のテストを指定して講義資料をアップロードする
      * @returns OK
      */
     $post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
-      query: Methods_by08hd["post"]["query"];
+      body: Methods0["post"]["reqBody"];
+      query: Methods0["post"]["query"];
       config?: T | undefined;
     }) =>
       fetch<
-        Methods_by08hd["post"]["resBody"],
+        Methods0["post"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["post"]["status"]
+        Methods0["post"]["status"]
       >(prefix, PATH0, POST, option)
         .json()
         .then((r) => r.body),
     $path: (
-      option?:
-        | { method: "post"; query: Methods_by08hd["post"]["query"] }
-        | undefined
+      option?: { method: "post"; query: Methods0["post"]["query"] } | undefined
     ) =>
       `${prefix}${PATH0}${
         option && option.query ? `?${dataToURLString(option.query)}` : ""

--- a/api/files/index.ts
+++ b/api/files/index.ts
@@ -15,7 +15,7 @@ export type Methods = {
 
     /** OK */
     resBody: {
-      fileId?: string | undefined;
+      fileId: string;
     };
 
     /** 講義と講義のテストを指定して講義資料をアップロードする */

--- a/api/index.ts
+++ b/api/index.ts
@@ -5,7 +5,7 @@ export type Methods = {
 
     /** OK */
     resBody: {
-      message?: string | undefined;
+      message: string;
     };
   };
 };

--- a/api/lectures/$api.ts
+++ b/api/lectures/$api.ts
@@ -1,7 +1,7 @@
 import type { AspidaClient, BasicHeaders } from "aspida";
-import type { Methods as Methods_by08hd } from ".";
-import type { Methods as Methods_1rmpaye } from "./_lecture_id/exams";
-import type { Methods as Methods_4ofto2 } from "./search";
+import type { Methods as Methods0 } from ".";
+import type { Methods as Methods1 } from "./_lecture_id/exams";
+import type { Methods as Methods2 } from "./search";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -24,18 +24,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
            */
           get: (option?: { config?: T | undefined } | undefined) =>
             fetch<
-              Methods_1rmpaye["get"]["resBody"],
+              Methods1["get"]["resBody"],
               BasicHeaders,
-              Methods_1rmpaye["get"]["status"]
+              Methods1["get"]["status"]
             >(prefix, `${prefix0}${PATH1}`, GET, option).json(),
           /**
            * @returns ok
            */
           $get: (option?: { config?: T | undefined } | undefined) =>
             fetch<
-              Methods_1rmpaye["get"]["resBody"],
+              Methods1["get"]["resBody"],
               BasicHeaders,
-              Methods_1rmpaye["get"]["status"]
+              Methods1["get"]["status"]
             >(prefix, `${prefix0}${PATH1}`, GET, option)
               .json()
               .then((r) => r.body),
@@ -49,26 +49,26 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @returns ok
        */
       post: (option: {
-        body: Methods_4ofto2["post"]["reqBody"];
+        body: Methods2["post"]["reqBody"];
         config?: T | undefined;
       }) =>
         fetch<
-          Methods_4ofto2["post"]["resBody"],
+          Methods2["post"]["resBody"],
           BasicHeaders,
-          Methods_4ofto2["post"]["status"]
+          Methods2["post"]["status"]
         >(prefix, PATH2, POST, option).json(),
       /**
        * @param option.body - 絞り込み
        * @returns ok
        */
       $post: (option: {
-        body: Methods_4ofto2["post"]["reqBody"];
+        body: Methods2["post"]["reqBody"];
         config?: T | undefined;
       }) =>
         fetch<
-          Methods_4ofto2["post"]["resBody"],
+          Methods2["post"]["resBody"],
           BasicHeaders,
-          Methods_4ofto2["post"]["status"]
+          Methods2["post"]["status"]
         >(prefix, PATH2, POST, option)
           .json()
           .then((r) => r.body),
@@ -79,18 +79,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      */
     get: (option?: { config?: T | undefined } | undefined) =>
       fetch<
-        Methods_by08hd["get"]["resBody"],
+        Methods0["get"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["get"]["status"]
+        Methods0["get"]["status"]
       >(prefix, PATH0, GET, option).json(),
     /**
      * @returns ok
      */
     $get: (option?: { config?: T | undefined } | undefined) =>
       fetch<
-        Methods_by08hd["get"]["resBody"],
+        Methods0["get"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["get"]["status"]
+        Methods0["get"]["status"]
       >(prefix, PATH0, GET, option)
         .json()
         .then((r) => r.body),
@@ -98,10 +98,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @param option.body - 講義の名前
      */
     post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<void, BasicHeaders, Methods_by08hd["post"]["status"]>(
+      fetch<void, BasicHeaders, Methods0["post"]["status"]>(
         prefix,
         PATH0,
         POST,
@@ -111,10 +111,10 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @param option.body - 講義の名前
      */
     $post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<void, BasicHeaders, Methods_by08hd["post"]["status"]>(
+      fetch<void, BasicHeaders, Methods0["post"]["status"]>(
         prefix,
         PATH0,
         POST,

--- a/api/lectures/index.ts
+++ b/api/lectures/index.ts
@@ -7,8 +7,8 @@ export type Methods = {
 
     /** ok */
     resBody: {
-      lectures?: Types.Lecture[] | undefined;
-      total?: number | undefined;
+      lectures: Types.Lecture[];
+      total: number;
     };
   };
 

--- a/api/lectures/search/$api.ts
+++ b/api/lectures/search/$api.ts
@@ -1,5 +1,5 @@
 import type { AspidaClient, BasicHeaders } from "aspida";
-import type { Methods as Methods_by08hd } from ".";
+import type { Methods as Methods0 } from ".";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -14,26 +14,26 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @returns ok
      */
     post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
       fetch<
-        Methods_by08hd["post"]["resBody"],
+        Methods0["post"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["post"]["status"]
+        Methods0["post"]["status"]
       >(prefix, PATH0, POST, option).json(),
     /**
      * @param option.body - 絞り込み
      * @returns ok
      */
     $post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
       fetch<
-        Methods_by08hd["post"]["resBody"],
+        Methods0["post"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["post"]["status"]
+        Methods0["post"]["status"]
       >(prefix, PATH0, POST, option)
         .json()
         .then((r) => r.body),

--- a/api/lectures/search/index.ts
+++ b/api/lectures/search/index.ts
@@ -7,11 +7,11 @@ export type Methods = {
 
     /** ok */
     resBody: {
-      lectures?: Types.Lecture[] | undefined;
-      total?: number | undefined;
+      lectures: Types.Lecture[];
+      total: number;
     };
 
     /** 絞り込み */
-    reqBody: Types.Lecture_req;
+    reqBody: Partial<Types.Lecture_req>;
   };
 };

--- a/api/login/$api.ts
+++ b/api/login/$api.ts
@@ -1,5 +1,5 @@
 import type { AspidaClient } from "aspida";
-import type { Methods as Methods_by08hd } from ".";
+import type { Methods as Methods0 } from ".";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -13,26 +13,28 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @param option.body - メールアドレスとパスワードを含めたjson
      */
     post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<
-        void,
-        Methods_by08hd["post"]["resHeaders"],
-        Methods_by08hd["post"]["status"]
-      >(prefix, PATH0, POST, option).send(),
+      fetch<void, Methods0["post"]["resHeaders"], Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      ).send(),
     /**
      * @param option.body - メールアドレスとパスワードを含めたjson
      */
     $post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<
-        void,
-        Methods_by08hd["post"]["resHeaders"],
-        Methods_by08hd["post"]["status"]
-      >(prefix, PATH0, POST, option)
+      fetch<void, Methods0["post"]["resHeaders"], Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      )
         .send()
         .then((r) => r.body),
     $path: () => `${prefix}${PATH0}`

--- a/api/login/index.ts
+++ b/api/login/index.ts
@@ -9,8 +9,8 @@ export type Methods = {
 
     /** メールアドレスとパスワードを含めたjson */
     reqBody: {
-      email?: string | undefined;
-      password?: string | undefined;
+      email: string;
+      password: string;
     };
   };
 };

--- a/api/signup/$api.ts
+++ b/api/signup/$api.ts
@@ -1,7 +1,7 @@
 import type { AspidaClient, BasicHeaders } from "aspida";
-import type { Methods as Methods_163xhtc } from "./auth";
-import type { Methods as Methods_1paaqvt } from "./mail";
-import type { Methods as Methods_1pbnd9f } from "./register";
+import type { Methods as Methods0 } from "./auth";
+import type { Methods as Methods1 } from "./mail";
+import type { Methods as Methods2 } from "./register";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -19,26 +19,26 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @returns 認証に成功したら、再びメールアドレスを返す
        */
       post: (option: {
-        body: Methods_163xhtc["post"]["reqBody"];
+        body: Methods0["post"]["reqBody"];
         config?: T | undefined;
       }) =>
         fetch<
-          Methods_163xhtc["post"]["resBody"],
+          Methods0["post"]["resBody"],
           BasicHeaders,
-          Methods_163xhtc["post"]["status"]
+          Methods0["post"]["status"]
         >(prefix, PATH0, POST, option).json(),
       /**
        * @param option.body - ワンタイムパスワードを含めたjson
        * @returns 認証に成功したら、再びメールアドレスを返す
        */
       $post: (option: {
-        body: Methods_163xhtc["post"]["reqBody"];
+        body: Methods0["post"]["reqBody"];
         config?: T | undefined;
       }) =>
         fetch<
-          Methods_163xhtc["post"]["resBody"],
+          Methods0["post"]["resBody"],
           BasicHeaders,
-          Methods_163xhtc["post"]["status"]
+          Methods0["post"]["status"]
         >(prefix, PATH0, POST, option)
           .json()
           .then((r) => r.body),
@@ -49,26 +49,28 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @param option.body - メールアドレスを含めたjson
        */
       post: (option: {
-        body: Methods_1paaqvt["post"]["reqBody"];
+        body: Methods1["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<
-          void,
-          Methods_1paaqvt["post"]["resHeaders"],
-          Methods_1paaqvt["post"]["status"]
-        >(prefix, PATH1, POST, option).send(),
+        fetch<void, Methods1["post"]["resHeaders"], Methods1["post"]["status"]>(
+          prefix,
+          PATH1,
+          POST,
+          option
+        ).send(),
       /**
        * @param option.body - メールアドレスを含めたjson
        */
       $post: (option: {
-        body: Methods_1paaqvt["post"]["reqBody"];
+        body: Methods1["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<
-          void,
-          Methods_1paaqvt["post"]["resHeaders"],
-          Methods_1paaqvt["post"]["status"]
-        >(prefix, PATH1, POST, option)
+        fetch<void, Methods1["post"]["resHeaders"], Methods1["post"]["status"]>(
+          prefix,
+          PATH1,
+          POST,
+          option
+        )
           .send()
           .then((r) => r.body),
       $path: () => `${prefix}${PATH1}`
@@ -78,26 +80,28 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * @param option.body - メールアドレス、名前、パスワードを含めたjson
        */
       post: (option: {
-        body: Methods_1pbnd9f["post"]["reqBody"];
+        body: Methods2["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<
-          void,
-          Methods_1pbnd9f["post"]["resHeaders"],
-          Methods_1pbnd9f["post"]["status"]
-        >(prefix, PATH2, POST, option).send(),
+        fetch<void, Methods2["post"]["resHeaders"], Methods2["post"]["status"]>(
+          prefix,
+          PATH2,
+          POST,
+          option
+        ).send(),
       /**
        * @param option.body - メールアドレス、名前、パスワードを含めたjson
        */
       $post: (option: {
-        body: Methods_1pbnd9f["post"]["reqBody"];
+        body: Methods2["post"]["reqBody"];
         config?: T | undefined;
       }) =>
-        fetch<
-          void,
-          Methods_1pbnd9f["post"]["resHeaders"],
-          Methods_1pbnd9f["post"]["status"]
-        >(prefix, PATH2, POST, option)
+        fetch<void, Methods2["post"]["resHeaders"], Methods2["post"]["status"]>(
+          prefix,
+          PATH2,
+          POST,
+          option
+        )
           .send()
           .then((r) => r.body),
       $path: () => `${prefix}${PATH2}`

--- a/api/signup/auth/$api.ts
+++ b/api/signup/auth/$api.ts
@@ -1,5 +1,5 @@
 import type { AspidaClient, BasicHeaders } from "aspida";
-import type { Methods as Methods_by08hd } from ".";
+import type { Methods as Methods0 } from ".";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -14,26 +14,26 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @returns 認証に成功したら、再びメールアドレスを返す
      */
     post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
       fetch<
-        Methods_by08hd["post"]["resBody"],
+        Methods0["post"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["post"]["status"]
+        Methods0["post"]["status"]
       >(prefix, PATH0, POST, option).json(),
     /**
      * @param option.body - ワンタイムパスワードを含めたjson
      * @returns 認証に成功したら、再びメールアドレスを返す
      */
     $post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
       fetch<
-        Methods_by08hd["post"]["resBody"],
+        Methods0["post"]["resBody"],
         BasicHeaders,
-        Methods_by08hd["post"]["status"]
+        Methods0["post"]["status"]
       >(prefix, PATH0, POST, option)
         .json()
         .then((r) => r.body),

--- a/api/signup/auth/index.ts
+++ b/api/signup/auth/index.ts
@@ -5,12 +5,12 @@ export type Methods = {
 
     /** 認証に成功したら、再びメールアドレスを返す */
     resBody: {
-      email?: string | undefined;
+      email: string;
     };
 
     /** ワンタイムパスワードを含めたjson */
     reqBody: {
-      oneTimePassword?: string | undefined;
+      oneTimePassword: string;
     };
   };
 };

--- a/api/signup/mail/$api.ts
+++ b/api/signup/mail/$api.ts
@@ -1,5 +1,5 @@
 import type { AspidaClient } from "aspida";
-import type { Methods as Methods_by08hd } from ".";
+import type { Methods as Methods0 } from ".";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -13,26 +13,28 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @param option.body - メールアドレスを含めたjson
      */
     post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<
-        void,
-        Methods_by08hd["post"]["resHeaders"],
-        Methods_by08hd["post"]["status"]
-      >(prefix, PATH0, POST, option).send(),
+      fetch<void, Methods0["post"]["resHeaders"], Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      ).send(),
     /**
      * @param option.body - メールアドレスを含めたjson
      */
     $post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<
-        void,
-        Methods_by08hd["post"]["resHeaders"],
-        Methods_by08hd["post"]["status"]
-      >(prefix, PATH0, POST, option)
+      fetch<void, Methods0["post"]["resHeaders"], Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      )
         .send()
         .then((r) => r.body),
     $path: () => `${prefix}${PATH0}`

--- a/api/signup/mail/index.ts
+++ b/api/signup/mail/index.ts
@@ -9,7 +9,7 @@ export type Methods = {
 
     /** メールアドレスを含めたjson */
     reqBody: {
-      email?: string | undefined;
+      email: string;
     };
   };
 };

--- a/api/signup/register/$api.ts
+++ b/api/signup/register/$api.ts
@@ -1,5 +1,5 @@
 import type { AspidaClient } from "aspida";
-import type { Methods as Methods_by08hd } from ".";
+import type { Methods as Methods0 } from ".";
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (
@@ -13,26 +13,28 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
      * @param option.body - メールアドレス、名前、パスワードを含めたjson
      */
     post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<
-        void,
-        Methods_by08hd["post"]["resHeaders"],
-        Methods_by08hd["post"]["status"]
-      >(prefix, PATH0, POST, option).send(),
+      fetch<void, Methods0["post"]["resHeaders"], Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      ).send(),
     /**
      * @param option.body - メールアドレス、名前、パスワードを含めたjson
      */
     $post: (option: {
-      body: Methods_by08hd["post"]["reqBody"];
+      body: Methods0["post"]["reqBody"];
       config?: T | undefined;
     }) =>
-      fetch<
-        void,
-        Methods_by08hd["post"]["resHeaders"],
-        Methods_by08hd["post"]["status"]
-      >(prefix, PATH0, POST, option)
+      fetch<void, Methods0["post"]["resHeaders"], Methods0["post"]["status"]>(
+        prefix,
+        PATH0,
+        POST,
+        option
+      )
         .send()
         .then((r) => r.body),
     $path: () => `${prefix}${PATH0}`

--- a/api/signup/register/index.ts
+++ b/api/signup/register/index.ts
@@ -9,9 +9,9 @@ export type Methods = {
 
     /** メールアドレス、名前、パスワードを含めたjson */
     reqBody: {
-      email?: string | undefined;
-      name?: string | undefined;
-      password?: string | undefined;
+      email: string;
+      name: string;
+      password: string;
     };
   };
 };

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -97,6 +97,31 @@ components:
         lectureName:
           type: string
           example: "有機化学3"
+        grade:
+          type: string
+          enum:
+            - B1
+            - B2
+            - B3
+            - B4
+            - M1
+            - M2
+            - D1
+            - D2
+            - D3
+          example: "B2"
+          nullable: true
+        term:
+          type: string
+          enum:
+            - 春
+            - 秋
+            - 春1
+            - 春2
+            - 秋1
+            - 秋2
+          example: "秋2"
+          nullable: true
     pdf:
       type: object
       description: pdfの詳細

--- a/mock_server/api/openapi.yaml
+++ b/mock_server/api/openapi.yaml
@@ -91,31 +91,6 @@ components:
       type: object
       description: 検索用パラメータ
       properties:
-        grade:
-          type: string
-          enum:
-            - B1
-            - B2
-            - B3
-            - B4
-            - M1
-            - M2
-            - D1
-            - D2
-            - D3
-          example: "B2"
-          nullable: true
-        term:
-          type: string
-          enum:
-            - 春
-            - 秋
-            - 春1
-            - 春2
-            - 秋1
-            - 秋2
-          example: "秋2"
-          nullable: true
         teacherName:
           type: string
           example: "田中角栄"


### PR DESCRIPTION
### 関連issue
#44 

### やったこと
- lectures/searchのrequestから`term`と`grade`を消しました
- 最新のopenapi.yamlからクライアントの型生成をしました
  - 思ったよりファイルの変更数が増えたのでPRを分けました

<img width="582" alt="スクリーンショット 2023-09-17 16 31 14" src="https://github.com/NU-wiki-web/nu-wiki-frontend/assets/83484258/8f1f84ac-676e-4c91-8900-73e43bcaf10e">
