### PR TITLE
Dockerの環境を整備

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-bullseye
+
+WORKDIR /workspace
+
+COPY package*.json ./
+COPY yarn.lock ./
+
+RUN apt-get update && apt-get install -y git
+RUN yarn install
+
+COPY . .
+
+CMD [ "yarn", "dev" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   node:
-    image: node:18-alpine3.17
+    build:
+      context: .
+      dockerfile: Dockerfile
     working_dir: /workspace
     volumes:
       - .:/workspace
@@ -9,6 +11,8 @@ services:
     ports:
       - 3000:3000
       - 24678:24678
-    command: "yarn dev"
+    stdin_open: true
+    tty: true
+    platform: linux/amd64
 volumes:
   node-module-volume:


### PR DESCRIPTION
## やったこと
- Dockerのイメージをalpineからbullseyeに変更
  - →yarn installでnode-gypのビルドにPythonが足りないよ！というエラーが出てしまうため
- Dockerfileを記述して、gitを入れるように変更
  - →yarn installのあとのhuskyのインストールを行えるようにするため