### PR TITLE
ログイン済みで見れるページと見れないページの制御を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 .cache
 .output
 .env
+.env*
 dist

--- a/components/pages/lecture/index.vue
+++ b/components/pages/lecture/index.vue
@@ -33,7 +33,7 @@
   const isError = ref<boolean>(false);
 
   client.lectures
-    .$get()
+    .get()
     .then(async (res) => {
       lectures.value = await res.lectures;
     })

--- a/middleware/checkLogin.global.ts
+++ b/middleware/checkLogin.global.ts
@@ -1,39 +1,23 @@
-export default defineNuxtRouteMiddleware((to, from) => {
+export default defineNuxtRouteMiddleware((to, _) => {
+  // クライアントサイドでは実行しない。
+  if (process.client) return;
   const sessionId = useCookie("SESSIONID");
-  console.log("middleware: sessionId", sessionId.value);
-  console.log("middleware: to.path", to.path);
-  //   if (to.path === "/login" || to.path === "/") {
-  //     return true;
-  //   }
-  //   if (!sessionId.value) {
-  //     return navigateTo("/login");
-  //   }
-  // }
-  const signupId = useCookie("SIGNUPID");
   const pathsAllowNonLogin = ["/login", "/", "/signup"];
   const signUpPaths = ["/signup/auth", "/signup/register"];
 
-  // if (to.path == "/login" && sessionId.value) {
-  //   console.log("middleware: redirect to /lecture-list");
-  //   return navigateTo("/lecture-list");
-  // }
-  // ログイン無しで見れるページは全て許可する
-  if (pathsAllowNonLogin.includes(to.path)) {
-    return true;
-  }
-
-  // ユーザー登録の途中なら許可
-  if (from.path == "/signup" && to.path == "/signup/auth") {
-    return true;
-  } else if (from.path == "/signup/auth" && to.path == "/signup/register") {
-    return true;
-  }
-
-  // ログインしていない場合はログイン画面へリダイレクト
-  if (!sessionId.value) {
-    console.log("middleware: redirect to /login");
-    return navigateTo("/login");
+  if (sessionId.value) {
+    // ログイン済みのとき
+    if (to.path === "/login" || signUpPaths.includes(to.path)) {
+      return navigateTo("/lecture-list");
+    }
+    return;
   } else {
-    return true;
+    if (pathsAllowNonLogin.includes(to.path) || signUpPaths.includes(to.path)) {
+      // ログイン無しで見れるページなら許可
+      return;
+    } else {
+      // それ以外はログインページにリダイレクト
+      return navigateTo("/login");
+    }
   }
 });

--- a/middleware/checkLogin.global.ts
+++ b/middleware/checkLogin.global.ts
@@ -1,0 +1,39 @@
+export default defineNuxtRouteMiddleware((to, from) => {
+  const sessionId = useCookie("SESSIONID");
+  console.log("middleware: sessionId", sessionId.value);
+  console.log("middleware: to.path", to.path);
+  //   if (to.path === "/login" || to.path === "/") {
+  //     return true;
+  //   }
+  //   if (!sessionId.value) {
+  //     return navigateTo("/login");
+  //   }
+  // }
+  const signupId = useCookie("SIGNUPID");
+  const pathsAllowNonLogin = ["/login", "/", "/signup"];
+  const signUpPaths = ["/signup/auth", "/signup/register"];
+
+  // if (to.path == "/login" && sessionId.value) {
+  //   console.log("middleware: redirect to /lecture-list");
+  //   return navigateTo("/lecture-list");
+  // }
+  // ログイン無しで見れるページは全て許可する
+  if (pathsAllowNonLogin.includes(to.path)) {
+    return true;
+  }
+
+  // ユーザー登録の途中なら許可
+  if (from.path == "/signup" && to.path == "/signup/auth") {
+    return true;
+  } else if (from.path == "/signup/auth" && to.path == "/signup/register") {
+    return true;
+  }
+
+  // ログインしていない場合はログイン画面へリダイレクト
+  if (!sessionId.value) {
+    console.log("middleware: redirect to /login");
+    return navigateTo("/login");
+  } else {
+    return true;
+  }
+});

--- a/pages/lecture-list/index.vue
+++ b/pages/lecture-list/index.vue
@@ -1,3 +1,4 @@
+<script setup lang="ts"></script>
 <template>
   <PagesLecture />
 </template>


### PR DESCRIPTION
## 概要
close #56 
ログインしてないときに、見えてはいけないページにアクセスできないようにしました。

## 詳細
ログインしてないときに見れるページ
- `/`
- `/login`
- `/signup/*`

それ以外のページ（`/upload`、`/lecture-list`）はログインしてないとリダイレクトされるようになるはずです

## 解決済み課題

- Nuxt3のmiddlewareで`useCookie`を使ってcookieを読み込むと、サーバー側のログではcookieが読み取れている用に見えるのに、ブラウザのログではcookieが表示されない。そのせいで無限リダイレクト？が発生してハイドレーションがぶっ壊れてえらいこっちゃなページが出来上がってしまう。どうすれば……

→middlewareがサーバーサイドとクライアントサイドの二回実行される。
`useCookie()`のcookie読み取り部分がこうなっていて
```javascript
function readRawCookies(opts = {}) {
  if (process.server) {
    return parse(useRequestEvent()?.req.headers.cookie || "", opts);
  } else if (process.client) {
    return parse(document.cookie, opts);
  }
}
```
サーバーサイドでは、送られてきたリクエストからcookieを読み取るけど、クライアントサイドではページが遷移する前？の`document.cookie`が読み取られてしまうので、クライアントにはcookieが存在しない状態になってしまう。
だから、middlewareに
```javascript
if (process.client) return true;
```
を追加してクライアントサイドではmiddlewareが実行されないようにする必要がある。